### PR TITLE
Changed scrollbar color so it is visible

### DIFF
--- a/main.css
+++ b/main.css
@@ -91,7 +91,7 @@
 	--scrollbar-thin-track: transparent !important;
 	--scrollbar-auto-thumb: var(--black0) !important;
 	--scrollbar-auto-track: var(--black3) !important;
-	--scrollbar-auto-scrollbar-color-thumb: var(--black3) !important;
+	--scrollbar-auto-scrollbar-color-thumb: var(--black1) !important;
 	--scrollbar-auto-scrollbar-color-track: var(--black3) !important;
 	--deprecated-store-bg: var(--black0) !important;
 }


### PR DESCRIPTION
Before `scrollbar-auto-scrollbar-color-thumb` and `scrollbar-auto-scrollbar-color-track` had the same value(`black3`) so you couldn't see where the scrollbar was unless you hovered over it.