### PR TITLE
chore: ignore node_modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/dist/catppuccin-frappe.theme.css
+++ b/dist/catppuccin-frappe.theme.css
@@ -325,6 +325,9 @@ div[class^=layerContainer] div[id^=channel-context] div[class^=scroller],
 div[class^=layerContainer] div[id^=user-context] div[class^=scroller] {
   overflow: hidden !important;
 }
+div[class^=layerContainer] div[class*=activity] div[class*=contents] {
+  color: #c6d0f5;
+}
 div[class^=layerContainer] > div[class^=layer] div[role=listbox] {
   background-color: #292c3c !important;
 }

--- a/dist/catppuccin-latte.theme.css
+++ b/dist/catppuccin-latte.theme.css
@@ -325,6 +325,9 @@ div[class^=layerContainer] div[id^=channel-context] div[class^=scroller],
 div[class^=layerContainer] div[id^=user-context] div[class^=scroller] {
   overflow: hidden !important;
 }
+div[class^=layerContainer] div[class*=activity] div[class*=contents] {
+  color: #4c4f69;
+}
 div[class^=layerContainer] > div[class^=layer] div[role=listbox] {
   background-color: #e6e9ef !important;
 }

--- a/dist/catppuccin-macchiato.theme.css
+++ b/dist/catppuccin-macchiato.theme.css
@@ -325,6 +325,9 @@ div[class^=layerContainer] div[id^=channel-context] div[class^=scroller],
 div[class^=layerContainer] div[id^=user-context] div[class^=scroller] {
   overflow: hidden !important;
 }
+div[class^=layerContainer] div[class*=activity] div[class*=contents] {
+  color: #cad3f5;
+}
 div[class^=layerContainer] > div[class^=layer] div[role=listbox] {
   background-color: #1e2030 !important;
 }

--- a/dist/catppuccin-mocha.theme.css
+++ b/dist/catppuccin-mocha.theme.css
@@ -325,6 +325,9 @@ div[class^=layerContainer] div[id^=channel-context] div[class^=scroller],
 div[class^=layerContainer] div[id^=user-context] div[class^=scroller] {
   overflow: hidden !important;
 }
+div[class^=layerContainer] div[class*=activity] div[class*=contents] {
+  color: #cdd6f4;
+}
 div[class^=layerContainer] > div[class^=layer] div[role=listbox] {
   background-color: #181825 !important;
 }

--- a/src/_theme.scss
+++ b/src/_theme.scss
@@ -368,6 +368,13 @@ div[class^="layerContainer"] {
 			overflow: hidden !important;
 		}
 	}
+	
+	// User popout activity buttons
+	div[class*="activity"] {
+		div[class*="contents"] {
+			color: $text;
+		}
+	}
 
 	> div[class^="layer"] {
 		// search popout


### PR DESCRIPTION
This should fix user popout buttons being the wrong color. CSS isn't my strongest suit, the selectors may not be optimal.
I also added a quick node_modules ignore because that should've been there from the start.

Before:
![image](https://user-images.githubusercontent.com/53945697/192178952-e581f051-c7cf-44ae-902b-34d540191c84.png)

After:
![image](https://user-images.githubusercontent.com/53945697/192178893-4fdaef4e-0cd3-48bf-91c5-184df21b7618.png)
