### PR TITLE
fix: Light theme nitro popout text is illegible

### DIFF
--- a/src/components/_popouts.scss
+++ b/src/components/_popouts.scss
@@ -164,6 +164,18 @@ section[class^="positionContainer-"] {
     -webkit-box-shadow: 0 0 0 1px $surface0,
       0 2px 10px 0 hsla(0, calc(var(--saturation-factor, 1) * 0%), 0%, 0.1);
   }
+
+  &[class*="profileColors-"] {
+    [class*="userTagUsernameBase-"],
+    [class*="discrimBase-"],
+    [class*="title-"],
+    [class*="roles-"],
+    [class*="defaultColor-"],
+    [class*="markup-"],
+    [class*="activityUserPopoutV2-"] * {
+      color: unset !important;
+    }
+  }
 }
 
 div[class^="layerContainer"] {


### PR DESCRIPTION
Fixes #54, while @nekowinston suggested a fix in the issue, that would mean discord light mode popouts would be set to dark mode style. This fix does not interfere with setting them to darkmode style, while also fixing the text being illegible.

With synced profile themes, Winstons solution (Fix applied, is not different than without the fix since it removes the `theme-light` class):
![1046](https://user-images.githubusercontent.com/53945697/199804738-336ea1b0-5490-4528-baa5-c927aefcb261.png)

Without the fix:
![26770](https://user-images.githubusercontent.com/53945697/199805211-cf45b6e7-bc37-4d8a-93cb-7fcc5c8d5dd4.png)

Without synced profile themes (Fix given by this PR):
![16585](https://user-images.githubusercontent.com/53945697/199804893-80acffeb-9ab6-4a91-a831-68ef60640744.png)
