### PR TITLE
fix: Light theme nitro popout status text illegible

### DIFF
--- a/src/components/_popouts.scss
+++ b/src/components/_popouts.scss
@@ -172,7 +172,8 @@ section[class^="positionContainer-"] {
     [class*="roles-"],
     [class*="defaultColor-"],
     [class*="markup-"],
-    [class*="activityUserPopoutV2-"] * {
+    [class*="activityUserPopoutV2-"] *,
+    [class*="customStatus-"] {
       color: unset !important;
     }
   }


### PR DESCRIPTION
Whoopsie, the 3 people i tested for making the other pull all didn't have a status set. My bad!