### PR TITLE
Add vencord spotify plugin theming

### DIFF
--- a/src/components/_buttons.scss
+++ b/src/components/_buttons.scss
@@ -70,11 +70,14 @@ div[class*="button-"][class*="dangerous-"]:hover {
 }
 
 // vencord spotify plugin button theming support (uses vencord-specific classes)
-.vc-spotify-button-row .vc-spotify-button& {
-  .vc-spotify-shuffle-on, .vc-spotify-repeat-context, .vc-spotify-repeat-track {
+.vc-spotify-button-row .vc-spotify-button {
+  &.vc-spotify-shuffle-on,
+  &.vc-spotify-repeat-context,
+  &.vc-spotify-repeat-track {
     color: var(--interactive-normal);
   }
-  .vc-spotify-repeat-off, .vc-spotify-shuffle-off {
+  &.vc-spotify-repeat-off,
+  &.vc-spotify-shuffle-off {
     color: var(--text-muted);
   }
 }

--- a/src/components/_buttons.scss
+++ b/src/components/_buttons.scss
@@ -68,3 +68,13 @@ div[class^="actionButtons-"] {
 div[class*="button-"][class*="dangerous-"]:hover {
   color: darken($red, 10%);
 }
+
+// vencord spotify plugin button theming support (uses vencord-specific classes)
+.vc-spotify-button-row .vc-spotify-button& {
+  .vc-spotify-shuffle-on, .vc-spotify-repeat-context, .vc-spotify-repeat-track {
+    color: var(--interactive-normal);
+  }
+  .vc-spotify-repeat-off, .vc-spotify-shuffle-off {
+    color: var(--text-muted);
+  }
+}


### PR DESCRIPTION
Colors shuffle and repeat colors to match their state<br>
Shuffle and repeat turned off:
<img width="231" alt="image" src="https://user-images.githubusercontent.com/102488279/200446826-f1b13b4d-53ae-4142-b64a-acbaab3fdb02.png">
Shuffle and repeat turned on:
<img width="205" alt="image" src="https://user-images.githubusercontent.com/102488279/200446866-02974584-7f80-4a4e-a220-c6b8e7e2df32.png">
Repeat single track:
<img width="204" alt="image" src="https://user-images.githubusercontent.com/102488279/200446912-681cf533-e0a5-4b2d-93e7-172bdf2819de.png">
