### PR TITLE
fix: offline status indicator color

### DIFF
--- a/src/components/_details.scss
+++ b/src/components/_details.scss
@@ -24,6 +24,7 @@ foreignObject[mask="url(#svg-mask-status-dnd)"] > div {
 // offline
 rect[fill^="hsl(214"],
 foreignObject[mask="url(#svg-mask-status-offline)"] > div,
+foreignObject[mask="url(#svg-mask-status-offline)"] > rect,
 div[class^="dotOffline"],
 i[class^="statusOffline-"] {
   fill: $subtext0 !important;


### PR DESCRIPTION
<img width="106" alt="image" src="https://user-images.githubusercontent.com/102488279/212905589-bf7c9935-838d-4fc4-b36d-8f2dfcf22e67.png">
<code> foreignObject > rect</code> works instead of <code>foreignObject > div</code> but I've still kept that incase it does apply somewhere