### PR TITLE
fix: Warning card popout text

### DIFF
--- a/src/components/_popouts.scss
+++ b/src/components/_popouts.scss
@@ -15,7 +15,9 @@ div[class^="layerContainer"] [role="menu"] {
       }
     }
 
-    &[role="menuitem"]:not([class*="colorDanger"]):not([id*="user-context-user-volume"]):hover {
+    &[role="menuitem"]:not([class*="colorDanger"]):not(
+        [id*="user-context-user-volume"]
+      ):hover {
       background: var(--background-accent);
       color: $crust;
 
@@ -396,6 +398,11 @@ div[class*="userInfoSection-"] {
   div[class^="connectedAccountContainer-"] {
     background-color: adjust-color($surface0, $alpha: -0.55) !important;
   }
+}
+
+// Warning card popouts ex. admin change username/account deletion
+div[class*="cardWarning-"] div[class*="warning-"] {
+  color: $base;
 }
 
 // emoji reactions in call


### PR DESCRIPTION
Before
![2454](https://user-images.githubusercontent.com/53945697/217257365-69032ac6-9f65-4eac-83c9-18228947793e.png)

After
![2621](https://user-images.githubusercontent.com/53945697/217257448-74dca8dd-ebdb-424c-a0f7-05895ecc5635.png)

I'm not sure if base is the right color to be using here. This also solves #130.