### PR TITLE
fix user status indicators and some popout headers

### DIFF
--- a/src/components/_details.scss
+++ b/src/components/_details.scss
@@ -1,5 +1,5 @@
 // online
-rect[fill="#3ba55c"],
+rect[fill="#23a55a"],
 foreignObject[mask="url(#svg-mask-status-online)"] > div,
 div[class^="dotOnline"],
 i[class^="statusOnline-"] {
@@ -7,34 +7,34 @@ i[class^="statusOnline-"] {
   background-color: $green !important;
 }
 
-rect[fill="rgba(59, 165, 92, 1)"] {
+rect[fill="rgba(35, 165, 90, 1)"] {
   fill: $green !important;
 }
 
 // idle
-rect[fill="#faa61a"],
+rect[fill="#f0b232"],
 foreignObject[mask="url(#svg-mask-status-idle)"] > div {
   fill: $yellow !important;
   background-color: $yellow !important;
 }
 
-rect[fill="rgba(250, 166, 26, 1)"] {
+rect[fill="rgba(240, 178, 50, 1)"] {
   fill: $yellow !important;
 }
 
 // dnd
-rect[fill="#ed4245"],
+rect[fill="#f23f43"],
 foreignObject[mask="url(#svg-mask-status-dnd)"] > div {
   fill: $red !important;
   background-color: $red !important;
 }
 
-rect[fill="rgba(237, 66, 69, 1)"] {
+rect[fill="rgba(242, 63, 67, 1)"] {
   fill: $red !important;
 }
 
 // offline
-rect[fill^="hsl(214"],
+rect[fill="#82858f"],
 foreignObject[mask="url(#svg-mask-status-offline)"] > div,
 foreignObject[mask="url(#svg-mask-status-offline)"] > rect,
 div[class^="dotOffline"],
@@ -43,7 +43,7 @@ i[class^="statusOffline-"] {
   background-color: $subtext0 !important;
 }
 
-rect[fill="rgba(116, 127, 141, 1)"] {
+rect[fill="rgba(130, 133, 143, 1)"] {
   fill: $subtext0 !important;
 }
 

--- a/src/components/_popouts.scss
+++ b/src/components/_popouts.scss
@@ -181,10 +181,6 @@ div[class*="layerContainer"] {
     div[class*="friendSelected"] {
       background: $surface0 !important;
     }
-
-    div[class*="header"] {
-      background: $mantle;
-    }
   }
 }
 


### PR DESCRIPTION
Fixes those issues:

- user indicators not being themed:
![image](https://user-images.githubusercontent.com/78933889/219518044-d9e5a1fc-bb96-4ce5-8846-d283e4a00fa5.png)
![image](https://user-images.githubusercontent.com/78933889/219518178-d2ec5818-98c6-4ead-a11a-1581b96aeed6.png)
- some headers in popouts having a background color set when they shouldn't:
![image](https://user-images.githubusercontent.com/78933889/219518413-207f7612-d412-4fd5-834b-ca4bc1bff046.png)
