### PR TITLE
feat: use autogenerated class name mappings

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -5,7 +5,8 @@ on:
     branches:
       - main
     paths:
-      - 'src/**'
+      - "src/**"
+  workflow_dispatch:
 
 jobs:
   deploy:

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -6,6 +6,8 @@ on:
       - main
     paths:
       - "src/**"
+  schedule:
+    - cron: "0 * * * *"
   workflow_dispatch:
 
 jobs:

--- a/mappings.mjs
+++ b/mappings.mjs
@@ -26,7 +26,10 @@ const classNameRegex =
 const classNameMap = new Map();
 
 [...originalCSS.matchAll(classNameRegex)].forEach((v) => {
-  classNameMap.set(v[1], v[0].substring(1, v[0].length - 1));
+  const mappedClass = v[0].substring(1, v[0].length - 1);
+
+  if (!classNameMap.has(v[1])) classNameMap.set(v[1], new Set([mappedClass]));
+  else classNameMap.get(v[1]).add(mappedClass);
 });
 
 console.log(`${classNameMap.size} class names found`);
@@ -45,9 +48,13 @@ await Promise.all(
       let newThemeCSS = themeCSS;
 
       for (const key of classNameMap.keys()) {
+        const hashedClasses = classNameMap.get(key);
+
         newThemeCSS = newThemeCSS.replaceAll(
           new RegExp(`\\.mapped\\-${key}(?=(\\.|,|\\{|\\[| |:|\\)))`, "g"),
-          `.${classNameMap.get(key)}`
+          hashedClasses.size > 5
+            ? `[class*=${key}-]`
+            : [...hashedClasses].map((k) => `.${k}`).join(", ")
         );
       }
 

--- a/mappings.mjs
+++ b/mappings.mjs
@@ -54,7 +54,7 @@ await Promise.all(
           new RegExp(`\\.mapped\\-${key}(?=(\\.|,|\\{|\\[| |:|\\)))`, "g"),
           hashedClasses.size > 5
             ? `[class*=${key}-]`
-            : [...hashedClasses].map((k) => `.${k}`).join(", ")
+            : `:is(${[...hashedClasses].map((k) => `.${k}`).join(", ")})`
         );
       }
 

--- a/mappings.mjs
+++ b/mappings.mjs
@@ -21,7 +21,8 @@ const originalCSSURL = new URL(
 ).toString();
 const originalCSS = await fetchThatCrashes(originalCSSURL);
 
-const classNameRegex = /\.([a-zA-Z-]+)\-[a-zA-Z0-9\_\-]{6}(?=(\.|,|\{|\[))/g;
+const classNameRegex =
+  /\.([a-zA-Z0-9\-]+)\-[a-zA-Z0-9\_\-]{6}(?=(\.|,|\{|\[| |:|\)))/g;
 const classNameMap = new Map();
 
 [...originalCSS.matchAll(classNameRegex)].forEach((v) => {
@@ -35,7 +36,7 @@ const lim = pLimit(10);
 await Promise.all(
   (
     await readdir("dist/dist/")
-  ).map((file, idx) => {
+  ).map((file) => {
     lim(async () => {
       const themeCSS = await readFile(`dist/dist/${file}`, {
         encoding: "utf-8",
@@ -45,7 +46,7 @@ await Promise.all(
 
       for (const key of classNameMap.keys()) {
         newThemeCSS = newThemeCSS.replaceAll(
-          `.mapped-${key}`,
+          new RegExp(`\\.mapped\\-${key}(?=(\\.|,|\\{|\\[| |:|\\)))`, "g"),
           `.${classNameMap.get(key)}`
         );
       }
@@ -56,7 +57,7 @@ await Promise.all(
 
       if (remainingMatches.length > 0) {
         console.warn(
-          "Unresolved class named found!",
+          "Unresolved class names found!",
           remainingMatches.map((k) => k[1])
         );
       }

--- a/mappings.mjs
+++ b/mappings.mjs
@@ -31,38 +31,15 @@ await Promise.all(
       let newThemeCSS = themeCSS;
 
       for (const key of classNameMap.keys()) {
-        newThemeCSS = newThemeCSS.replaceAll(
-          `[class*=${key}]`,
-          `.${classNameMap.get(key)}`
-        );
-        newThemeCSS = newThemeCSS.replaceAll(
-          `[class^=${key}]`,
-          `.${classNameMap.get(key)}`
-        );
-        newThemeCSS = newThemeCSS.replaceAll(
-          `[class*="${key}"]`,
-          `.${classNameMap.get(key)}`
-        );
-        newThemeCSS = newThemeCSS.replaceAll(
-          `[class^="${key}"]`,
-          `.${classNameMap.get(key)}`
-        );
-        newThemeCSS = newThemeCSS.replaceAll(
-          `[class*=${key}-]`,
-          `.${classNameMap.get(key)}`
-        );
-        newThemeCSS = newThemeCSS.replaceAll(
-          `[class^=${key}-]`,
-          `.${classNameMap.get(key)}`
-        );
-        newThemeCSS = newThemeCSS.replaceAll(
-          `[class*="${key}-"]`,
-          `.${classNameMap.get(key)}`
-        );
-        newThemeCSS = newThemeCSS.replaceAll(
-          `[class^="${key}-"]`,
-          `.${classNameMap.get(key)}`
-        );
+        newThemeCSS = newThemeCSS
+          .replaceAll(`[class*=${key}]`, `.${classNameMap.get(key)}`)
+          .replaceAll(`[class^=${key}]`, `.${classNameMap.get(key)}`)
+          .replaceAll(`[class*="${key}"]`, `.${classNameMap.get(key)}`)
+          .replaceAll(`[class^="${key}"]`, `.${classNameMap.get(key)}`)
+          .replaceAll(`[class*=${key}-]`, `.${classNameMap.get(key)}`)
+          .replaceAll(`[class^=${key}-]`, `.${classNameMap.get(key)}`)
+          .replaceAll(`[class*="${key}-"]`, `.${classNameMap.get(key)}`)
+          .replaceAll(`[class^="${key}-"]`, `.${classNameMap.get(key)}`);
       }
 
       await writeFile(`dist/dist/${file}`, newThemeCSS);

--- a/mappings.mjs
+++ b/mappings.mjs
@@ -53,7 +53,7 @@ await Promise.all(
         newThemeCSS = newThemeCSS.replaceAll(
           new RegExp(`\\.mapped\\-${key}(?=(\\.|,|\\{|\\[| |:|\\)))`, "g"),
           hashedClasses.size > 5
-            ? `[class*=${key}-]`
+            ? `:is([class^=${key}-], [class*=" ${key}-"])`
             : hashedClasses.size > 1
             ? `:is(${[...hashedClasses].map((k) => `.${k}`).join(", ")})`
             : `.${[...hashedClasses][0]}`

--- a/mappings.mjs
+++ b/mappings.mjs
@@ -8,7 +8,7 @@ const originalCSSURL = new URL(
 ).toString();
 const originalCSS = await fetch(originalCSSURL).then((res) => res.text());
 
-const classNameRegex = /\.([a-zA-Z-]+)\-[a-zA-Z0-9]{6}(,|\{)/g;
+const classNameRegex = /\.([a-zA-Z-]+)\-[a-zA-Z0-9\_\-]{6}(?=(\.|,|\{|\[))/g;
 const classNameMap = new Map();
 
 [...originalCSS.matchAll(classNameRegex)].forEach((v) => {
@@ -22,7 +22,7 @@ const lim = pLimit(10);
 await Promise.all(
   (
     await readdir("dist/dist/")
-  ).map((file) => {
+  ).map((file, idx) => {
     lim(async () => {
       const themeCSS = await readFile(`dist/dist/${file}`, {
         encoding: "utf-8",
@@ -34,6 +34,17 @@ await Promise.all(
         newThemeCSS = newThemeCSS.replaceAll(
           `.mapped-${key}`,
           `.${classNameMap.get(key)}`
+        );
+      }
+
+      const remainingMatches = [
+        ...newThemeCSS.matchAll(/\.mapped\-([a-zA-Z]+)/g),
+      ];
+
+      if (remainingMatches.length > 0) {
+        console.warn(
+          "Unresolved class named found!",
+          remainingMatches.map((k) => k[1])
         );
       }
 

--- a/mappings.mjs
+++ b/mappings.mjs
@@ -26,7 +26,7 @@ const classNameRegex =
 const classNameMap = new Map();
 
 [...originalCSS.matchAll(classNameRegex)].forEach((v) => {
-  const mappedClass = v[0].substring(1, v[0].length - 1);
+  const mappedClass = v[0].substring(1);
 
   if (!classNameMap.has(v[1])) classNameMap.set(v[1], new Set([mappedClass]));
   else classNameMap.get(v[1]).add(mappedClass);
@@ -54,7 +54,9 @@ await Promise.all(
           new RegExp(`\\.mapped\\-${key}(?=(\\.|,|\\{|\\[| |:|\\)))`, "g"),
           hashedClasses.size > 5
             ? `[class*=${key}-]`
-            : `:is(${[...hashedClasses].map((k) => `.${k}`).join(", ")})`
+            : hashedClasses.size > 1
+            ? `:is(${[...hashedClasses].map((k) => `.${k}`).join(", ")})`
+            : `.${[...hashedClasses][0]}`
         );
       }
 

--- a/mappings.mjs
+++ b/mappings.mjs
@@ -1,12 +1,25 @@
 import { readdir, readFile, writeFile } from "node:fs/promises";
 import pLimit from "p-limit";
 
-const html = await fetch("https://discord.com/app").then((res) => res.text());
+/**
+ * winston
+ * @param {string} url
+ */
+const fetchThatCrashes = async (url) => {
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error(`Error fetching ${url}: ${res.status} ${res.statusText}`);
+  }
+
+  return res.text();
+};
+
+const html = await fetchThatCrashes("https://discord.com/app");
 const originalCSSURL = new URL(
   html.match(/<link rel="stylesheet" href="([/a-zA-Z0-9\.]+)"/)[1],
   "https://discord.com/"
 ).toString();
-const originalCSS = await fetch(originalCSSURL).then((res) => res.text());
+const originalCSS = await fetchThatCrashes(originalCSSURL);
 
 const classNameRegex = /\.([a-zA-Z-]+)\-[a-zA-Z0-9\_\-]{6}(?=(\.|,|\{|\[))/g;
 const classNameMap = new Map();

--- a/mappings.mjs
+++ b/mappings.mjs
@@ -31,15 +31,10 @@ await Promise.all(
       let newThemeCSS = themeCSS;
 
       for (const key of classNameMap.keys()) {
-        newThemeCSS = newThemeCSS
-          .replaceAll(`[class*=${key}]`, `.${classNameMap.get(key)}`)
-          .replaceAll(`[class^=${key}]`, `.${classNameMap.get(key)}`)
-          .replaceAll(`[class*="${key}"]`, `.${classNameMap.get(key)}`)
-          .replaceAll(`[class^="${key}"]`, `.${classNameMap.get(key)}`)
-          .replaceAll(`[class*=${key}-]`, `.${classNameMap.get(key)}`)
-          .replaceAll(`[class^=${key}-]`, `.${classNameMap.get(key)}`)
-          .replaceAll(`[class*="${key}-"]`, `.${classNameMap.get(key)}`)
-          .replaceAll(`[class^="${key}-"]`, `.${classNameMap.get(key)}`);
+        newThemeCSS = newThemeCSS.replaceAll(
+          `.mapped-${key}`,
+          `.${classNameMap.get(key)}`
+        );
       }
 
       await writeFile(`dist/dist/${file}`, newThemeCSS);

--- a/mappings.mjs
+++ b/mappings.mjs
@@ -1,0 +1,72 @@
+import { readdir, readFile, writeFile } from "node:fs/promises";
+import pLimit from "p-limit";
+
+const html = await fetch("https://discord.com/app").then((res) => res.text());
+const originalCSSURL = new URL(
+  html.match(/<link rel="stylesheet" href="([/a-zA-Z0-9\.]+)"/)[1],
+  "https://discord.com/"
+).toString();
+const originalCSS = await fetch(originalCSSURL).then((res) => res.text());
+
+const classNameRegex = /\.([a-zA-Z-]+)\-[a-zA-Z0-9]{6}(,|\{)/g;
+const classNameMap = new Map();
+
+[...originalCSS.matchAll(classNameRegex)].forEach((v) => {
+  classNameMap.set(v[1], v[0].substring(1, v[0].length - 1));
+});
+
+console.log(`${classNameMap.size} class names found`);
+
+const lim = pLimit(10);
+
+await Promise.all(
+  (
+    await readdir("dist/dist/")
+  ).map((file) => {
+    lim(async () => {
+      const themeCSS = await readFile(`dist/dist/${file}`, {
+        encoding: "utf-8",
+      });
+
+      let newThemeCSS = themeCSS;
+
+      for (const key of classNameMap.keys()) {
+        newThemeCSS = newThemeCSS.replaceAll(
+          `[class*=${key}]`,
+          `.${classNameMap.get(key)}`
+        );
+        newThemeCSS = newThemeCSS.replaceAll(
+          `[class^=${key}]`,
+          `.${classNameMap.get(key)}`
+        );
+        newThemeCSS = newThemeCSS.replaceAll(
+          `[class*="${key}"]`,
+          `.${classNameMap.get(key)}`
+        );
+        newThemeCSS = newThemeCSS.replaceAll(
+          `[class^="${key}"]`,
+          `.${classNameMap.get(key)}`
+        );
+        newThemeCSS = newThemeCSS.replaceAll(
+          `[class*=${key}-]`,
+          `.${classNameMap.get(key)}`
+        );
+        newThemeCSS = newThemeCSS.replaceAll(
+          `[class^=${key}-]`,
+          `.${classNameMap.get(key)}`
+        );
+        newThemeCSS = newThemeCSS.replaceAll(
+          `[class*="${key}-"]`,
+          `.${classNameMap.get(key)}`
+        );
+        newThemeCSS = newThemeCSS.replaceAll(
+          `[class^="${key}-"]`,
+          `.${classNameMap.get(key)}`
+        );
+      }
+
+      await writeFile(`dist/dist/${file}`, newThemeCSS);
+      console.log(`Processed ${file}`);
+    });
+  })
+);

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
   ],
   "private": true,
   "scripts": {
-    "build": "mkdir -p dist/dist; sass -I node_modules --no-charset --no-source-map src:dist/dist",
-    "release": "node build.js; mkdir -p dist/dist; sass -I node_modules --no-charset --no-source-map src:dist/dist; rm src/catppuccin-*-*.theme.scss",
+    "build": "mkdir -p dist/dist; sass -I node_modules --no-charset --no-source-map src:dist/dist; node mappings.mjs",
+    "release": "node build.js; mkdir -p dist/dist; sass -I node_modules --no-charset --no-source-map src:dist/dist; node mappings.mjs; rm src/catppuccin-*-*.theme.scss",
     "watch": "mkdir -p dist/dist; sass -I node_modules --no-charset --no-source-map src:dist/dist -w",
     "prepare": "husky install"
   },
@@ -26,6 +26,7 @@
     "@catppuccin/palette": "^0.1.6",
     "husky": ">=6",
     "lint-staged": ">=10",
+    "p-limit": "^4.0.0",
     "prettier": "^2.7.1",
     "sass": "^1.55.0"
   },

--- a/src/catppuccin-frappe.theme.scss
+++ b/src/catppuccin-frappe.theme.scss
@@ -13,7 +13,7 @@
 
 $brand: $blue;
 
-button[class*="emojiButtonNormal"] > div > div {
+button.mapped-emojiButtonNormal > div > div {
   filter: grayscale(0.77) hue-rotate(185deg) brightness(1.015) opacity(100%) !important;
 }
 

--- a/src/catppuccin-latte.theme.scss
+++ b/src/catppuccin-latte.theme.scss
@@ -13,7 +13,7 @@
 
 $brand: $blue;
 
-button[class*="emojiButtonNormal"] > div > div {
+button.mapped-emojiButtonNormal > div > div {
   filter: grayscale(0.77) hue-rotate(185deg) brightness(0.7) opacity(100%)
     contrast(2) !important;
 }
@@ -263,7 +263,7 @@ button[class*="emojiButtonNormal"] > div > div {
   --interactive-active: #{$text};
 
   // "spine" svgs before threads
-  svg[class^="spine-"] {
+  svg.mapped-spine {
     color: $surface2;
   }
 
@@ -305,7 +305,7 @@ button[class*="emojiButtonNormal"] > div > div {
   }
 }
 
-nav[class*="guilds-"].theme-dark {
+nav.mapped-guilds.theme-dark {
   @import "@catppuccin/palette/scss/mocha";
 
   // server icons
@@ -313,8 +313,8 @@ nav[class*="guilds-"].theme-dark {
     background-color: lighten($base, 2%);
 
     &:hover,
-    &[class*="selected"] {
-      > div[class^="childWrapper-"] {
+    &.mapped-selected {
+      > div.mapped-childWrapper {
         color: $crust;
         font-weight: 600;
       }
@@ -327,10 +327,10 @@ nav[class*="guilds-"].theme-dark {
   }
 
   // lightens folder wrapper bg
-  span[class^="expandedFolderBackground-"] {
+  span.mapped-expandedFolderBackground {
     background-color: lighten($base, 3%);
   }
-  div[class^="folder-"][class*="hover-"] {
+  div.mapped-folder.mapped-hover {
     background-color: lighten($base, 8%);
   }
 
@@ -341,14 +341,14 @@ nav[class*="guilds-"].theme-dark {
   }
 
   // server list icons
-  div[class^="upperBadge"] {
-    > div[class^="iconBadge"] {
+  div.mapped-upperBadge {
+    > div.mapped-iconBadge {
       path {
         color: $base;
       }
     }
 
-    div[class*="participating-"] {
+    div.mapped-participating {
       background: $green;
     }
   }

--- a/src/catppuccin-macchiato.theme.scss
+++ b/src/catppuccin-macchiato.theme.scss
@@ -13,7 +13,7 @@
 
 $brand: $blue;
 
-button[class*="emojiButtonNormal"] > div > div {
+button.mapped-emojiButtonNormal > div > div {
   filter: grayscale(0.77) hue-rotate(185deg) brightness(1.03) opacity(100%) !important;
 }
 

--- a/src/catppuccin-mocha.theme.scss
+++ b/src/catppuccin-mocha.theme.scss
@@ -13,7 +13,7 @@
 
 $brand: $blue;
 
-button[class*="emojiButtonNormal"] > div > div {
+button.mapped-emojiButtonNormal > div > div {
   filter: grayscale(0.77) hue-rotate(185deg) brightness(1.02) opacity(100%) !important;
 }
 

--- a/src/components/_buttons.scss
+++ b/src/components/_buttons.scss
@@ -1,45 +1,45 @@
 // filled buttons and badges should have crust text
-[class*="lookFilled-"] {
-  &[class*="colorBrand-"],
-  &[class*="colorBrandNew-"],
-  &[class*="colorLink-"],
-  &[class*="colorYellow-"],
-  &[class*="colorRed-"],
-  &[class*="colorGreen-"] {
+.mapped-lookFilled {
+  &.mapped-colorBrand,
+  &.mapped-colorBrandNew,
+  &.mapped-colorLink,
+  &.mapped-colorYellow,
+  &.mapped-colorRed,
+  &.mapped-colorGreen {
     color: $crust;
 
     // darken the nitro button too
-    svg[class^="premiumIcon"] {
+    svg.mapped-premiumIcon {
       color: darken($pink, 20%);
     }
 
     // spinner color
-    [class*="spinnerItem-"] {
+    .mapped-spinnerItem {
       background-color: $crust;
     }
 
-    [class*="defaultColor-"] {
+    .mapped-defaultColor {
       color: $crust;
     }
   }
 
   // ...unless it's primary
-  &[class*="colorPrimary-"] {
+  &.mapped-colorPrimary {
     color: $text;
   }
 }
 
 // buttons in sidebar when in calls
-div[class^="actionButtons-"] {
-  [class^="button-"][class*="buttonColor-"],
-  [class^="button-"] [class*="buttonColor-"] {
+div.mapped-actionButtons {
+  .mapped-button.mapped-buttonColor,
+  .mapped-button .mapped-buttonColor {
     background-color: $surface1;
 
-    &[class*="buttonActive-"] {
+    &.mapped-buttonActive {
       background-color: $green;
       color: $crust;
 
-      [class*="buttonContents-"] {
+      .mapped-buttonContents {
         color: $crust;
 
         svg {
@@ -51,11 +51,11 @@ div[class^="actionButtons-"] {
 }
 
 // lookInverted buttons should have darker brand text
-[class*="lookInverted-"][class*="colorBrand-"] {
+.mapped-lookInverted.mapped-colorBrand {
   color: var(--brand-experiment-600);
 
   // darken the nitro button too
-  svg[class^="premiumIcon"] {
+  svg.mapped-premiumIcon {
     color: darken($pink, 15%);
   }
 }
@@ -63,35 +63,36 @@ div[class^="actionButtons-"] {
 // lookLink + colorPrimary should be themed
 .theme-dark,
 .theme-light {
-  [class*="lookLink-"][class*="colorPrimary-"] {
+  .mapped-lookLink.mapped-colorPrimary {
     color: $text;
   }
-  [class*="lookFilled-"][class*="colorTransparent-"] {
+  .mapped-lookFilled.mapped-colorTransparent {
     color: $text;
     background-color: $surface0;
   }
 }
 
 // dangerous button when hovered is colored properly
-div[class*="button-"][class*="dangerous-"]:hover {
+div.mapped-button.mapped-dangerous:hover {
   color: darken($red, 10%);
 }
 
 // make all selected radio buttons's text crust
-div[role="radio"][class*="selected"] {
+div[role="radio"].mapped-selected {
   color: $crust;
 
   // make the allow radio button's bg to the correct green
-  &[class*="allow"] {
+  &.mapped-allow {
     background-color: $green;
   }
 }
 //nonspecific radio buttons
-[class*="container-"][style*="background-color: var(--green-360)"] {
+.mapped-container[style*="background-color: var(--green-360)"] {
   --green-360: #{$green}; //vencord plugin settings
   background-color: $green !important;
 }
-[class*="container-"][style*="background-color: var(--primary-400)"], [class*="container-"][style*="background-color: rgb(130, 133, 143)"] {
+.mapped-container[style*="background-color: var(--primary-400)"],
+.mapped-container[style*="background-color: rgb(130, 133, 143)"] {
   background-color: $crust !important; //used in a lot of places
 }
 // vencord spotify plugin button theming support (uses vencord-specific classes)
@@ -108,7 +109,7 @@ div[role="radio"][class*="selected"] {
 }
 
 // these badges appear in the emoji/sticker picker
-[class*="topGuildEmojiBadge-"] {
+.mapped-topGuildEmojiBadge {
   background: linear-gradient(268.26deg, $peach, $red 102.45%);
 
   * {
@@ -116,7 +117,7 @@ div[role="radio"][class*="selected"] {
   }
 }
 
-[class*="newlyAddedBadge-"] {
+.mapped-newlyAddedBadge {
   background: linear-gradient(268.26deg, $teal, $green 102.45%);
 
   * {
@@ -125,8 +126,6 @@ div[role="radio"][class*="selected"] {
 }
 
 //revert nitro icon on nitro subscribe button on external emoji
-[class*="lookFilled-"]
-  [class*="premiumSubscribeButton-"]
-  > [class*="premiumIcon-"] {
+.mapped-lookFilled .mapped-premiumSubscribeButton > .mapped-premiumIcon {
   color: $crust !important;
 }

--- a/src/components/_catppuccin-server.scss
+++ b/src/components/_catppuccin-server.scss
@@ -164,33 +164,33 @@ $channelicons: (
   )
 );
 
-div[class*="unread-"],
-div[class^="jumpToPresentBar-"] > button,
-div[class^="newMessagesBar-"] > button {
+div.mapped-unread,
+div.mapped-jumpToPresentBar > button,
+div.mapped-newMessagesBar > button {
   color: $base;
 }
 
 // rules
 a[href="/channels/907385605422448742/992579279835639808"] {
-  *[class^="icon"] {
+  *.mapped-icon {
     color: $red !important;
   }
 }
 
 // announcements
 a[href="/channels/907385605422448742/918688623002550313"] {
-  *[class^="icon"] {
+  *.mapped-icon {
     color: $green !important;
   }
 }
 
 @each $channelid, $icon in $channelicons {
   a[href="/channels/907385605422448742/#{$channelid}"] {
-    *[class*="icon"] {
+    *.mapped-icon {
       color: transparent !important;
     }
 
-    div[class^="iconContainer"]:before {
+    div.mapped-iconContainer:before {
       content: " ";
       -webkit-mask: url("#{map-get($icon, icon)}");
       position: absolute;
@@ -376,15 +376,15 @@ $roleColors: (
 
 @each $colorVal, $colorDec in $roleColors {
   //role colors in chat and sidebar
-  [class*="username-"][style*="#{$colorVal}"] {
+  .mapped-username[style*="#{$colorVal}"] {
     color: #{map-get($colorDec, color)} !important;
   }
   //role color circles
-  [class*="roleCircle-"][style*="#{$colorVal}"] {
+  .mapped-roleCircle[style*="#{$colorVal}"] {
     background-color: #{map-get($colorDec, color)} !important;
   }
   //vencord platform colors
-  [class*="typing-"] strong[style*="#{$colorVal}"] {
+  .mapped-typing strong[style*="#{$colorVal}"] {
     color: #{map-get($colorDec, color)} !important;
   }
 }

--- a/src/components/_chat.scss
+++ b/src/components/_chat.scss
@@ -69,7 +69,9 @@
   //   color: $overlay0;
   // }
 
-  .mapped-inlineCode {
+  .mapped-inlineCode,
+  .mapped-after_inlineCode,
+  .mapped-before_inlineCode {
     background: $surface0;
   }
 

--- a/src/components/_chat.scss
+++ b/src/components/_chat.scss
@@ -1,11 +1,11 @@
-[class^="chatContent"] {
-  div[class*="wrapperAudio-"],
-  div[class*="imageWrapper-"] {
-    div[class*="audioControls"],
-    div[class*="videoControls-"] {
+.mapped-chatContent {
+  div.mapped-wrapperAudio,
+  div.mapped-imageWrapper {
+    div.mapped-audioControls,
+    div.mapped-videoControls {
       background-color: #{adjust-color($mantle, $alpha: -0.2)};
 
-      svg[class*="controlIcon-"] {
+      svg.mapped-controlIcon {
         opacity: 1;
         color: $subtext1;
       }
@@ -14,28 +14,28 @@
 
   // new message ruler
   #---new-messages-bar {
-    span[class^="unreadPill-"] {
+    span.mapped-unreadPill {
       color: $crust;
     }
   }
 
   // new message bar
-  div[class^="newMessagesBar-"] {
+  div.mapped-newMessagesBar {
     button {
       color: $crust;
     }
   }
 
   // text input area
-  div[class^="channelTextArea-"] {
-    div[class^="buttons-"] * {
+  div.mapped-channelTextArea {
+    div.mapped-buttons * {
       color: var(--interactive-normal) !important;
     }
   }
 
   // reactions
   [id^="message-reactions-"] {
-    div[class^="reaction-"] {
+    div.mapped-reaction {
       background-color: $surface0;
       &:hover {
         background-color: var(--brand-experiment-20a);
@@ -45,9 +45,9 @@
   }
 
   // chat header
-  div[class^="container-"][class*="header-"] {
-    div[class*="addReactButton-"],
-    div[class^="buttons-"]:not([class*="lookBlank-"]) div[class^="contents"] {
+  div.mapped-container.mapped-header {
+    div.mapped-addReactButton,
+    div.mapped-buttons:not(.mapped-lookBlank) div.mapped-contents {
       background: $surface0;
       &:hover {
         background-color: var(--brand-experiment-20a);
@@ -57,19 +57,19 @@
   }
 
   // "Messages failed to load" bar
-  div[class^="messagesErrorBar-"] div[class*="barButtonBase-"] {
+  div.mapped-messagesErrorBar div.mapped-barButtonBase {
     color: $crust;
   }
 
   // code stuff
   // [class*="after_inlineCode-"],
   // [class*="before_inlineCode-"],
-  // [class^="syntaxBefore-"],
-  // [class^="syntaxAfter-"] {
+  // .mapped-syntaxBefore,
+  // .mapped-syntaxAfter {
   //   color: $overlay0;
   // }
 
-  [class*="inlineCode-"] {
+  .mapped-inlineCode {
     background: $surface0;
   }
 
@@ -77,9 +77,9 @@
     background: $surface0;
   }
 
-  div[class^="container-"] div[class^="cardWrapper-"] {
-    div[class*="completed-"] {
-      svg[class^="checkmark-"] {
+  div.mapped-container div.mapped-cardWrapper {
+    div.mapped-completed {
+      svg.mapped-checkmark {
         background-color: $green;
         color: $crust;
       }
@@ -94,7 +94,7 @@ div[style*="d1382af8d9e755bc44811b1fd92990a8.svg"] {
 }
 
 // server boost icon... again
-main[class^="chatContent"] div[id^="message-content-"] svg[class^="icon-"] {
+main.mapped-chatContent div[id^="message-content-"] svg.mapped-icon {
   > path[d="M4 0L0 4V8L4 12L8 8V4L4 0ZM7 7.59L4 10.59L1 7.59V4.41L4 1.41L7 4.41V7.59Z"],
   > path[d="M2 4.83V7.17L4 9.17L6 7.17V4.83L4 2.83L2 4.83Z"] {
     color: $pink;
@@ -104,11 +104,11 @@ main[class^="chatContent"] div[id^="message-content-"] svg[class^="icon-"] {
 // spoiler messages
 .theme-dark,
 .theme-light {
-  span[class^="spoilerText"],
-  div[class^="spoilerText"] {
+  span.mapped-spoilerText,
+  div.mapped-spoilerText {
     background-color: $surface0;
 
-    &[class*="hidden"] {
+    &.mapped-hidden {
       background-color: $surface2;
 
       &:hover {
@@ -117,44 +117,44 @@ main[class^="chatContent"] div[id^="message-content-"] svg[class^="icon-"] {
     }
   }
 
-  div[class^="spoilerContainer-"] {
-    div[class^="spoilerWarning-"] {
+  div.mapped-spoilerContainer {
+    div.mapped-spoilerWarning {
       color: $text;
       background-color: adjust-color($crust, $alpha: -0.3);
     }
 
     &:hover {
-      div[class^="spoilerWarning-"] {
+      div.mapped-spoilerWarning {
         color: $text;
         background-color: $crust;
       }
     }
 
-    article[class*="embedFull-"] {
+    article.mapped-embedFull {
       border-color: $surface2;
     }
   }
 }
 
 // cooldown text
-div[class^="cooldownWrapper-"] {
+div.mapped-cooldownWrapper {
   color: var(--text-muted) !important;
 }
 
 // autocomplete chat textboxes
-div[class*="autocomplete-"] {
+div.mapped-autocomplete {
   background-color: $mantle !important;
 
-  div[class*="categoryHeader"] {
+  div.mapped-categoryHeader {
     background-color: $mantle !important;
   }
-  div[class*="autocompleteRowSubheading"] {
+  div.mapped-autocompleteRowSubheading {
     background-color: transparent;
   }
-  div[class*="autocompleteRowContentSecondary"] {
+  div.mapped-autocompleteRowContentSecondary {
     background-color: transparent;
   }
-  div[class^="usageWrapper-"] > div[class*="title-"] {
+  div.mapped-usageWrapper > div.mapped-title {
     color: $brand !important;
   }
 
@@ -164,12 +164,12 @@ div[class*="autocomplete-"] {
 }
 
 // emoji button
-div[class^="channelTextArea-"] button[class*="emojiButton-"] {
+div.mapped-channelTextArea button.mapped-emojiButton {
   background: transparent !important;
 }
 
 // upload???
-[class*="uploadDropModal-"] div[class^="inner"] {
+.mapped-uploadDropModal div.mapped-inner {
   border-color: $crust;
 
   * {
@@ -178,12 +178,12 @@ div[class^="channelTextArea-"] button[class*="emojiButton-"] {
 }
 
 // forums
-div[class^="chat"] > div[class^="content-"] > div[class^="container-"] {
+div.mapped-chat > div.mapped-content > div.mapped-container {
   background-color: $base;
 
   // forum icons
-  div[class^="pinIcon-"],
-  div[class^="stepStatus-"] {
+  div.mapped-pinIcon,
+  div.mapped-stepStatus {
     > svg > path {
       fill: $subtext0;
     }
@@ -196,58 +196,58 @@ div[class^="chat"] > div[class^="content-"] > div[class^="container-"] {
     }
   }
 
-  div[class*="countText"] {
+  div.mapped-countText {
     color: $crust;
   }
 
   // discord icon
-  svg[class^="discordIcon-"] {
+  svg.mapped-discordIcon {
     background-color: $brand;
     color: $crust;
   }
 
   // new badge
-  div[class^="newBadge-"] {
+  div.mapped-newBadge {
     background-color: $lavender !important;
     color: $crust;
   }
 
-  div[class*="mainCard-"] {
+  div.mapped-mainCard {
     background-color: $surface0;
   }
 }
 
-div[class^="sidebar-"] > section[class^="panels-"] {
-  svg[class*="buttonIcon-"],
-  div[class*="buttonContents"] {
+div.mapped-sidebar > section.mapped-panels {
+  svg.mapped-buttonIcon,
+  div.mapped-buttonContents {
     fill: $text;
     color: $text;
   }
 }
 
 [data-list-id^="forum-channel-list-"] {
-  div[class^="body-"] > div[class^="tags"] div[class*="pill"] {
+  div.mapped-body > div.mapped-tags div.mapped-pill {
     background-color: $mantle;
   }
 
   // new post button
-  button[class^="submitButton-"][class*="colorBrand"] {
+  button.mapped-submitButton.mapped-colorBrand {
     background-color: $brand;
     color: $crust;
   }
 }
 
 // fix the sidebar on smaller servers
-div[class^="chat"]
-  > div[class^="content-"]
-  main[class^="chatContent-"]
-  + div[class^="container-"] {
+div.mapped-chat
+  > div.mapped-content
+  main.mapped-chatContent
+  + div.mapped-container {
   background-color: var(--background-secondary);
 }
 
 // calls
-div[class^="callContainer-"] {
-  [class*="controlIcon-"] {
+div.mapped-callContainer {
+  .mapped-controlIcon {
     color: $subtext1;
 
     &:hover {
@@ -255,93 +255,92 @@ div[class^="callContainer-"] {
     }
   }
 
-  div[class*="tile-"],
-  div[class*="background-"] {
+  div.mapped-tile,
+  div.mapped-background {
     background-color: $base !important;
   }
 
-  div[class*="overlayTitle"],
-  svg[class*="status-"] {
+  div.mapped-overlayTitle,
+  svg.mapped-status {
     background-color: $surface0;
     color: $text;
   }
 
-  div[class*="header"],
-  svg[class*="selectedIcon-"] {
+  div.mapped-header,
+  svg.mapped-selectedIcon {
     color: $text;
   }
 
-  div[class*="button-"][class*="contents-"],
-  button[class*="cta-"],
-  button[class*="participantsButton-"] {
+  div.mapped-button.mapped-contents,
+  button.mapped-cta,
+  button.mapped-participantsButton {
     background-color: $surface0;
     color: $text;
   }
 
-  div[class^="videoControls-"] {
-    div[class^="children-"] {
-      div[class*="playingText-"] {
+  div.mapped-videoControls {
+    div.mapped-children {
+      div.mapped-playingText {
         color: $subtext1;
       }
     }
 
-    div[class^="toolbar-"] {
-      svg[class^="controlIcon-"] {
+    div.mapped-toolbar {
+      svg.mapped-controlIcon {
         color: var(--interactive-normal);
       }
 
-      div[class^="streamQualityIndicator-"]
-        div[class^="liveQualityIndicator-"] {
+      div.mapped-streamQualityIndicator div.mapped-liveQualityIndicator {
         background-color: $surface1 !important;
 
-        div[class^="qualityIndicator-"] {
+        div.mapped-qualityIndicator {
           color: $text;
         }
 
-        svg[class^="premiumStreamIcon"] {
+        svg.mapped-premiumStreamIcon {
           color: $text;
         }
       }
 
-      div[class^="liveIndicator-"] div[class^="live-"] {
+      div.mapped-liveIndicator div.mapped-live {
         background-color: $red !important;
         color: $crust !important;
       }
     }
 
-    button[class*="leftTrayIcon-"][class*="buttonColor-"] {
+    button.mapped-leftTrayIcon.mapped-buttonColor {
       background-color: $surface0;
       color: $text;
     }
 
-    [class*="colorable-"] {
-      &[class*="red-"] {
+    .mapped-colorable {
+      &.mapped-red {
         background: $red;
 
-        [class*="centerIcon-"] {
+        .mapped-centerIcon {
           color: $crust;
         }
       }
 
-      &[class*="primaryDark-"] {
+      &.mapped-primaryDark {
         background: $surface1;
         color: $text;
 
-        [class*="centerIcon-"] {
+        .mapped-centerIcon {
           color: $text;
         }
       }
 
-      &[class*="white-"] {
+      &.mapped-white {
         color: $crust;
         background-color: $subtext1;
 
-        [class*="centerIcon-"] {
+        .mapped-centerIcon {
           color: $crust;
         }
 
         &:hover,
-        &[class*="active-"] {
+        &.mapped-active {
           background: $text;
         }
       }
@@ -350,29 +349,29 @@ div[class^="callContainer-"] {
 }
 
 // gifts
-div[class*="giftCodeContainer"] [class*="tile"] {
+div.mapped-giftCodeContainer .mapped-tile {
   background-color: $mantle;
 
-  > [class*="description"] {
+  > .mapped-description {
     color: $text;
   }
 }
 
 // channels & roles
-div[class*="chat-"] {
+div.mapped-chat {
   // header
-  section[class*="header-"] {
+  section.mapped-header {
     background-color: $mantle;
   }
 
-  div[class*="content-"][class*="container-"] {
+  div.mapped-content.mapped-container {
     background-color: $mantle;
 
-    div[class*="container"] {
+    div.mapped-container {
       background-color: $mantle;
     }
 
-    div[class*="search-"] {
+    div.mapped-search {
       background-color: $base !important;
 
       input::placeholder {
@@ -380,16 +379,16 @@ div[class*="chat-"] {
       }
     }
 
-    div[class*="browser"] {
-      div[class*="content"] div[class^="container-"] {
+    div.mapped-browser {
+      div.mapped-content div.mapped-container {
         background-color: $base;
       }
     }
 
-    div[class*="scrollerContainer-"] {
+    div.mapped-scrollerContainer {
       background-color: $mantle;
 
-      div[class*="checkIcon-"][style*="opacity: 1;"] > svg > path {
+      div.mapped-checkIcon[style*="opacity: 1;"] > svg > path {
         fill: $crust;
       }
     }
@@ -398,71 +397,69 @@ div[class*="chat-"] {
       background-color: $mantle;
       border-bottom: 2px solid $surface0;
 
-      [class*="textBadge-"] {
+      .mapped-textBadge {
         color: $crust;
       }
     }
   }
 }
 
-div[class*="chat-"] {
+div.mapped-chat {
   // Search Box
-  section[class*="title"] div[class*="searchBar"] span[class*="search"] {
+  section.mapped-title div.mapped-searchBar span.mapped-search {
     background-color: $surface0;
     color: $text;
   }
 
   // Search Results Active Button
-  nav[class*="pageControl"]
-    div[class*="roundButton"][class*="activeButton"]
-    span {
+  nav.mapped-pageControl div.mapped-roundButton.mapped-activeButton span {
     color: $crust;
   }
 }
 
-div[class*="chat-"] {
+div.mapped-chat {
   // Forum Gallery View
-  li[class*="mainCard-"][class*="container"] {
+  li.mapped-mainCard.mapped-container {
     background-color: $surface0;
 
     &:hover {
       background-color: $surface1;
     }
 
-    div[class*="contentPreview-"] {
+    div.mapped-contentPreview {
       background-color: $base;
       border: none;
 
-      div[class*="textContentFooter-"] {
+      div.mapped-textContentFooter {
         background: none;
       }
     }
 
-    div[class*="tags-"] {
-      div[class*="tagPill-"] {
+    div.mapped-tags {
+      div.mapped-tagPill {
         background-color: #{adjust-color($surface1, $alpha: -0.2)};
       }
     }
   }
 
   // Empty Pages
-  div[class*="emptyPage"] {
+  div.mapped-emptyPage {
     background-color: $base;
   }
 
   // Stupid gradient
-  div[class*="innerHeader"]:after {
+  div.mapped-innerHeader:after {
     background: none;
   }
 }
 
 // spotify listen along invite
-[id*="message-accessories-"] > [class*="invite-"] {
+[id*="message-accessories-"] > .mapped-invite {
   background-color: $base;
-  [class*="inFront-"][class*="header-"] {
+  .mapped-inFront.mapped-header {
     color: $subtext0;
   }
-  [class*="partyStatus-"] {
+  .mapped-partyStatus {
     color: $text;
   }
 }

--- a/src/components/_details.scss
+++ b/src/components/_details.scss
@@ -1,8 +1,8 @@
 // online
 rect[fill="#23a55a"],
 foreignObject[mask="url(#svg-mask-status-online)"] > div,
-div[class^="dotOnline"],
-i[class^="statusOnline-"] {
+div.mapped-dotOnline,
+i.mapped-statusOnline {
   fill: $green !important;
   background-color: $green !important;
 }
@@ -37,8 +37,8 @@ rect[fill="rgba(242, 63, 67, 1)"] {
 rect[fill="#82858f"],
 foreignObject[mask="url(#svg-mask-status-offline)"] > div,
 foreignObject[mask="url(#svg-mask-status-offline)"] > rect,
-div[class^="dotOffline"],
-i[class^="statusOffline-"] {
+div.mapped-dotOffline,
+i.mapped-statusOffline {
   fill: $subtext0 !important;
   background-color: $subtext0 !important;
 }
@@ -69,15 +69,15 @@ rect[fill="#593695"] {
 
 //recolor spotify platform indicator
 [src="/assets/eaeac24163b35f7526704a3d9b3c7722.svg"] {
-    width: 0;
-    padding: 12px;
-    height: 0;
-    -webkit-mask-image: url("https://discord.com/assets/eaeac24163b35f7526704a3d9b3c7722.svg");
-    background: $green;
+  width: 0;
+  padding: 12px;
+  height: 0;
+  -webkit-mask-image: url("https://discord.com/assets/eaeac24163b35f7526704a3d9b3c7722.svg");
+  background: $green;
 }
 
 // dots in typing
-svg[class^="cursorDefault-"] svg[class^="dots-"] circle {
+svg.mapped-cursorDefault svg.mapped-dots circle {
   fill: $base !important;
 }
 
@@ -88,107 +88,109 @@ svg[class^="cursorDefault-"] svg[class^="dots-"] circle {
 }
 
 // for those roles that blend in the background
-span[class*="username-"][style*="color: rgb(54, 57, 62)"],
-span[class*="username-"][style*="color: rgb(53, 57, 64)"] {
+span.mapped-username[style*="color: rgb(54, 57, 62)"],
+span.mapped-username[style*="color: rgb(53, 57, 64)"] {
   color: var(--background-primary) !important;
 }
 
 // server badges
-div[class*="flowerStarContainer-"] {
-  &[class*="boostedGuildTierIconBackgroundWithVisibleBanner"] {
-    svg[class*="flowerStar-"] * {
+div.mapped-flowerStarContainer {
+  &.mapped-boostedGuildTierIconBackgroundWithVisibleBanner {
+    svg.mapped-flowerStar * {
       fill: #fff;
     }
-    div[class^="childContainer-"] svg * {
+    div.mapped-childContainer svg * {
       fill: $crust;
     }
   }
 
-  &[class*="iconBackgroundTierOne-"],
-  &[class*="iconBackgroundTierTwo-"]:not([class*="boostedGuildTierIconBackgroundWithVisibleBanner"]) {
-    svg[class*="flowerStar-"] * {
+  &.mapped-iconBackgroundTierOne,
+  &.mapped-iconBackgroundTierTwo:not(
+      .mapped-boostedGuildTierIconBackgroundWithVisibleBanner
+    ) {
+    svg.mapped-flowerStar * {
       fill: $surface2;
     }
-    div[class^="childContainer-"] svg * {
+    div.mapped-childContainer svg * {
       fill: $text;
     }
   }
 
-  &[class*="iconBackgroundTierThree-"] {
-    svg[class*="flowerStar-"] * {
+  &.mapped-iconBackgroundTierThree {
+    svg.mapped-flowerStar * {
       fill: $pink;
     }
-    div[class^="childContainer-"] svg * {
+    div.mapped-childContainer svg * {
       fill: $crust;
     }
   }
 
-  &[class*="verified-"] {
-    svg[class*="flowerStar-"] * {
+  &.mapped-verified {
+    svg.mapped-flowerStar * {
       fill: $green;
     }
-    div[class^="childContainer-"] svg * {
+    div.mapped-childContainer svg * {
       fill: $crust;
     }
   }
 
-  &[class*="partnered-"] {
-    svg[class*="flowerStar-"] * {
+  &.mapped-partnered {
+    svg.mapped-flowerStar * {
       fill: $brand;
     }
-    div[class^="childContainer-"] svg * {
+    div.mapped-childContainer svg * {
       fill: $crust;
     }
   }
 }
 
 // public / verified server info pill
-div[class^="communityInfoPill"] {
+div.mapped-communityInfoPill {
   --background-accent: #{adjust-color($base, $alpha: -0.3)};
   color: $text;
 
-  div[class^="text"] {
+  div.mapped-text {
     font-weight: 500;
   }
 }
 
 // social links on "what's new"
-a[class*="socialLink-"][href*="discord"] {
+a.mapped-socialLink[href*="discord"] {
   color: $subtext0;
 }
 
 // upload icon
-svg[class^="uploadIcon"] {
+svg.mapped-uploadIcon {
   color: $crust;
 }
 
 // empty states. why is it colored like this
 .theme-dark,
 .theme-light {
-  h2[class^="emptyStateHeader-"] {
+  h2.mapped-emptyStateHeader {
     color: $text;
   }
 
-  p[class^="emptyStateSubtext-"] {
+  p.mapped-emptyStateSubtext {
     color: $subtext0;
   }
 }
 
 // anything that uses a color background should have crust text
-div[class*="unreadMentionsBar-"],
-div[class*="unreadBar-"] {
+div.mapped-unreadMentionsBar,
+div.mapped-unreadBar {
   color: $crust;
 }
 
 // make number badges have crust text and bolder
-div[class*="numberBadge-"] {
+div.mapped-numberBadge {
   font-weight: 700;
   color: $crust;
 }
 
 // spotify button on text area
-button[class^="attachButton-"] {
-  svg path[class^="attachButtonPlay-"] {
+button.mapped-attachButton {
+  svg path.mapped-attachButtonPlay {
     color: $green;
     fill: $green;
   }
@@ -196,7 +198,7 @@ button[class^="attachButton-"] {
 
 // speaking indicator
 
-div[class*="avatarSpeaking-"] {
+div.mapped-avatarSpeaking {
   -webkit-box-shadow: inset 0 0 0 2px $green,
     inset 0 0 0 3px var(--background-secondary);
   box-shadow: inset 0 0 0 2px $green,
@@ -204,43 +206,43 @@ div[class*="avatarSpeaking-"] {
 }
 
 //new discord speaking indicator fix
-[class*="border-"][class*="speaking-"] {
+.mapped-border.mapped-speaking {
   --green-360: $green;
 }
 
-div[class*="videoLayer-"] > div[class^="tileChild"] > div[class^="border"] {
-  &[class*="speaking-"] {
+div.mapped-videoLayer > div.mapped-tileChild > div.mapped-border {
+  &.mapped-speaking {
     -webkit-box-shadow: inset 0 0 0 2px $green, inset 0 0 0 3px $green;
     box-shadow: inset 0 0 0 2px $green, inset 0 0 0 3px $green;
   }
 
   // this is when emojis fly across the tile
-  &[class*="voiceChannelEffect-"] {
+  &.mapped-voiceChannelEffect {
     -webkit-box-shadow: inset 0 0 0 2px $brand, inset 0 0 0 3px $brand;
     box-shadow: inset 0 0 0 2px $brand, inset 0 0 0 3px $brand;
   }
 }
 
-div[class*="featureIcon-"] path {
+div.mapped-featureIcon path {
   fill: $brand;
 }
 
-div[class*="backgroundAccent-"] {
+div.mapped-backgroundAccent {
   color: $crust;
 }
 
-div[class*="profileBadges-"] {
+div.mapped-profileBadges {
   div[aria-label="Supports Commands"] img {
     content: url("data:image/svg+xml,%3Csvg viewBox='0 0 24 24' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='%23#{str-slice(inspect($green), 2)}'%3E%3Cpath d='m8.1176653 16.0847263 4.8330812-8.1694527h2.9315882l-4.8330812 8.1694527z'/%3E%3Cpath d='m20.4189453 9.4038086v-2.4311524c0-1.9775391-1.0825195-3.1118164-2.9697266-3.1118164h-1.5581055v1.7802734l.9594727-.0014648c.8540039 0 1.34375.5683594 1.34375 1.5585938v2.3969727c0 .8300781.1806641 1.8422852 1.5893555 2.3100586l.2856445.0947265-.2856445.0947266c-1.4086914.4677734-1.5893555 1.4799804-1.5893555 2.3100586v2.3964844c0 .9907227-.4897461 1.559082-1.34375 1.559082l-.9594727-.0014648v1.7802734h1.5581055c1.887207 0 2.9697266-1.1342773 2.9697266-3.1118164v-2.4316406c0-1.2583008.3432617-1.6264648 1.5810547-1.6445312v-1.9023438c-1.237793-.0180665-1.5810547-.3862305-1.5810547-1.6450196z'/%3E%3Cpath d='m5.8061523 7.1982422c0-.9760742.5024414-1.5585938 1.3432617-1.5585938l.9594727.0014648v-1.7802734h-1.5576172c-1.887207 0-2.9697266 1.1342773-2.9697266 3.1118164v2.4311523c0 1.2587891-.3432617 1.6269531-1.581543 1.6450195v1.9023438c1.2382812.0180664 1.581543.3862305 1.581543 1.6445312v2.4316406c0 1.9775391 1.0825195 3.1118164 2.9697266 3.1118164h1.5576172v-1.7802734l-.9594727.0014648c-.8408203 0-1.3432617-.5830078-1.3432617-1.559082v-2.3964844c0-.8300781-.1806641-1.8422852-1.5898438-2.3100586l-.2856444-.0947264.2856445-.0947266c1.4091797-.4677734 1.5898437-1.4799804 1.5898437-2.3100586z'/%3E%3C/g%3E%3C/svg%3E");
   }
 }
 
-div[class*="newBadge-"],
-div[class*="tryItOutBadge-"] {
+div.mapped-newBadge,
+div.mapped-tryItOutBadge {
   color: $crust;
 }
 
-span[class*="channelMention"]:hover,
-[class*="mention"]:not([class*="mentionButton-"], [class*="mentionIcon-"]):hover {
+span.mapped-channelMention:hover,
+.mapped-mention:not(.mapped-mentionButton, .mapped-mentionIcon):hover {
   color: $crust;
 }

--- a/src/components/_icons-bgImg.scss
+++ b/src/components/_icons-bgImg.scss
@@ -22,7 +22,7 @@ $bgImg: (
 );
 
 @each $class, $icon in $bgImg {
-  [class*="#{$class}-"] {
+  .mapped-#{$class} {
     background-image: url("#{map-get($icon, icon)}") !important;
   }
 }

--- a/src/components/_icons-imgContent.scss
+++ b/src/components/_icons-imgContent.scss
@@ -6,7 +6,7 @@ $imgContent: (
 );
 
 @each $class, $icon in $imgContent {
-  [class*="#{$class}-"] {
+  .mapped-#{$class} {
     content: url("#{map-get($icon, icon)}") !important;
   }
 }

--- a/src/components/_icons-svgBg.scss
+++ b/src/components/_icons-svgBg.scss
@@ -7,7 +7,7 @@ $svgBg: (
 @each $class, $color in $svgBg {
   .theme-dark,
   .theme-light {
-    svg[class*="#{$class}-"] {
+    svg.mapped-#{$class} {
       background-color: #{map-get($color, color)};
     }
   }

--- a/src/components/_icons-svgColor.scss
+++ b/src/components/_icons-svgColor.scss
@@ -70,7 +70,7 @@ $svgColor: (
 @each $class, $color in $svgColor {
   .theme-dark,
   .theme-light {
-    svg[class*="#{$class}-"] {
+    svg.mapped-#{$class} {
       color: #{map-get($color, color)} !important;
     }
   }

--- a/src/components/_navbar.scss
+++ b/src/components/_navbar.scss
@@ -1,11 +1,11 @@
-nav[class*="guilds-"] {
+nav.mapped-guilds {
   // server icons
   foreignObject > div[data-list-item-id^="guildsnav_"] {
     background-color: lighten($base, 2%);
 
     &:hover,
-    &[class*="selected"] {
-      > div[class^="childWrapper-"] {
+    &.mapped-selected {
+      > div.mapped-childWrapper {
         color: $crust;
         font-weight: 600;
       }
@@ -18,10 +18,10 @@ nav[class*="guilds-"] {
   }
 
   // lightens folder wrapper bg
-  span[class^="expandedFolderBackground-"] {
+  span.mapped-expandedFolderBackground {
     background-color: lighten($base, 3%);
   }
-  div[class^="folder-"][class*="hover-"] {
+  div.mapped-folder.mapped-hover {
     background-color: lighten($base, 8%);
   }
 
@@ -33,16 +33,16 @@ nav[class*="guilds-"] {
 }
 
 // server list icons
-div[class^="upperBadge"] {
-  > div[class^="iconBadge"] path {
+div.mapped-upperBadge {
+  > div.mapped-iconBadge path {
     color: $crust;
   }
 
-  div[class*="participating-"] {
+  div.mapped-participating {
     background: $green;
   }
 }
 
-div[class^="lowerBadge"] div[class^="iconBadge"] path {
+div.mapped-lowerBadge div.mapped-iconBadge path {
   color: $crust;
 }

--- a/src/components/_pages.scss
+++ b/src/components/_pages.scss
@@ -1,26 +1,26 @@
 // settings
-div[class^="sidebarRegion-"] {
-  div[class^="serverBoostTabItem-"] {
-    svg[class^="icon-"] {
+div.mapped-sidebarRegion {
+  div.mapped-serverBoostTabItem {
+    svg.mapped-icon {
       fill: $pink !important;
     }
 
-    &[class*="selected-"] {
+    &.mapped-selected {
       background-color: $brand !important;
       color: $crust !important;
 
-      svg[class^="icon-"] {
+      svg.mapped-icon {
         fill: $crust !important;
       }
     }
   }
 
-  div[class^="premiumTab-"] {
+  div.mapped-premiumTab {
     > div > svg > path {
       fill: $pink;
     }
 
-    > div[class*="selected"] {
+    > div.mapped-selected {
       color: $crust;
 
       svg > path {
@@ -29,7 +29,7 @@ div[class^="sidebarRegion-"] {
     }
   }
 
-  div[class*="tabBarItemContainer-"] [class*="textBadge-"] {
+  div.mapped-tabBarItemContainer .mapped-textBadge {
     color: $crust;
 
     &[style*="background-color: var(--brand-500);"] {
@@ -38,13 +38,13 @@ div[class^="sidebarRegion-"] {
   }
 }
 
-div[class^="contentRegion-"] {
-  div[class*="noticeRegion-"] div[style="background-color: rgb(24, 25, 28);"] {
+div.mapped-contentRegion {
+  div.mapped-noticeRegion div[style="background-color: rgb(24, 25, 28);"] {
     background-color: $crust !important;
   }
 
   // #my-account-tab {
-  //     div[class^="userSettingsSecurity-"] {
+  //     div.mapped-userSettingsSecurity {
   //         h5::after {
   //             content: " ";
   //             z-index: 10;
@@ -58,13 +58,13 @@ div[class^="contentRegion-"] {
   // }
 
   // color bars with ticks
-  [class^="bar-"],
-  [class^="markDash-"] {
+  .mapped-bar,
+  .mapped-markDash {
     background: $surface1;
   }
 
   [id="privacy-&-safety-tab"] {
-    div[class^="radioBar-"] {
+    div.mapped-radioBar {
       &[style*="hsl(139,"] {
         border-color: $green;
       }
@@ -78,20 +78,20 @@ div[class^="contentRegion-"] {
       }
     }
 
-    div[class*="betaTagIcon"] {
+    div.mapped-betaTagIcon {
       background-color: $brand !important;
       color: $crust;
     }
   }
 
   #accessibility-tab {
-    button[class*="colorBrandNew"] {
+    button.mapped-colorBrandNew {
       background-color: $brand;
     }
   }
 
   #keybinds-tab {
-    span[class*="key"] {
+    span.mapped-key {
       color: $crust;
       g {
         fill: $crust;
@@ -100,19 +100,19 @@ div[class^="contentRegion-"] {
   }
 
   #nitro-server-boost-tab {
-    circle[class^="circleProgress-"] {
+    circle.mapped-circleProgress {
       color: $pink;
     }
 
-    div[class*="gemIndicatorContainer-"] {
+    div.mapped-gemIndicatorContainer {
       background-color: $base;
 
-      div[class^="tierLabel-"] {
+      div.mapped-tierLabel {
         color: $subtext1;
       }
     }
 
-    button[class*="lookInverted-"] {
+    button.mapped-lookInverted {
       color: $crust;
       background-color: $text;
 
@@ -121,27 +121,27 @@ div[class^="contentRegion-"] {
       }
     }
 
-    div[class*="card-"],
-    h3[class*="price-"] {
+    div.mapped-card,
+    h3.mapped-price {
       color: $text !important;
     }
   }
 
   #subscriptions-tab {
-    [class^="sectionAccountCredit-"],
-    [class^="subscriptionDetails-"] {
+    .mapped-sectionAccountCredit,
+    .mapped-subscriptionDetails {
       border-color: var(--background-modifier-accent);
     }
   }
 
   #library-inventory-tab {
-    div[class^="promotionIcon-"] {
+    div.mapped-promotionIcon {
       background-color: $base;
     }
   }
 
   #discord-nitro-tab {
-    button[class*="buttonWhite"] {
+    button.mapped-buttonWhite {
       color: $text !important;
       border-color: $text !important;
     }
@@ -150,19 +150,19 @@ div[class^="contentRegion-"] {
       color: $text !important;
     }
 
-    svg[class*="sparkleStar-"] {
+    svg.mapped-sparkleStar {
       color: $text;
     }
 
-    div[class*="description-"] {
+    div.mapped-description {
       color: $subtext1 !important;
     }
 
-    div[class*="card-"] {
+    div.mapped-card {
       color: $text;
     }
 
-    button[class*="lookInverted-"] {
+    button.mapped-lookInverted {
       color: $crust;
       background-color: $text;
 
@@ -173,45 +173,45 @@ div[class^="contentRegion-"] {
   }
 
   #billing-tab {
-    div[class*="subtext"] {
+    div.mapped-subtext {
       color: $subtext1;
     }
 
-    [class*="Divider"] {
+    .mapped-Divider {
       border-color: var(--background-modifier-accent);
     }
 
-    div[class^="defaultIndicator-"] {
+    div.mapped-defaultIndicator {
       color: $text;
       background-color: $surface1;
     }
 
-    div[class*="summaryInfo"],
-    [class^="paymentHeader-"] {
+    div.mapped-summaryInfo,
+    .mapped-paymentHeader {
       color: $text;
       border-color: var(--background-modifier-accent);
     }
 
-    div[class^="premiumIndicator-"] {
+    div.mapped-premiumIndicator {
       color: $crust;
     }
 
-    div[class^="paymentPane-"],
-    div[class*="paginator-"],
-    div[class*="payment-"] {
+    div.mapped-paymentPane,
+    div.mapped-paginator,
+    div.mapped-payment {
       background-color: $surface0;
       color: $text;
     }
 
-    div[class^="expandedInfo-"] {
+    div.mapped-expandedInfo {
       background-color: $surface1;
     }
 
-    [class*="paymentText-"] {
+    .mapped-paymentText {
       color: $subtext1;
     }
 
-    div[class^="codeRedemptionRedirect-"] {
+    div.mapped-codeRedemptionRedirect {
       background-color: $mantle;
       color: $text;
       border-color: $surface0;
@@ -219,25 +219,25 @@ div[class^="contentRegion-"] {
   }
 
   [id="voice-&-video-tab"] {
-    div[class^="backgroundOptionRing-"] {
+    div.mapped-backgroundOptionRing {
       border-color: $brand;
     }
   }
 
   #notifications-tab {
-    button[class*="marketingUnsubscribeButton-"] {
+    button.mapped-marketingUnsubscribeButton {
       color: $text;
     }
   }
 
   #game-activity-tab {
-    div[class*="nowPlayingAdd-"],
-    div[class*="lastPlayed-"],
-    div[class*="overlayStatusText-"] {
+    div.mapped-nowPlayingAdd,
+    div.mapped-lastPlayed,
+    div.mapped-overlayStatusText {
       color: var(--text-muted);
     }
 
-    div[class*="activeGame-"][class*="nowPlaying"] * {
+    div.mapped-activeGame.mapped-nowPlaying * {
       color: $crust;
 
       svg > g > path {
@@ -245,11 +245,11 @@ div[class^="contentRegion-"] {
       }
     }
 
-    input[class^="gameName-"] {
+    input.mapped-gameName {
       color: $text;
     }
 
-    input[class*="gameNameInput-"] {
+    input.mapped-gameNameInput {
       &:hover,
       &:focus {
         background-color: $mantle;
@@ -258,41 +258,41 @@ div[class^="contentRegion-"] {
       }
     }
 
-    div[class*="game-"] {
+    div.mapped-game {
       -webkit-box-shadow: 0 1px 0 0 var(--background-modifier-accent);
       box-shadow: 0 1px 0 0 var(--background-modifier-accent);
     }
 
-    div[class*="removeGame-"] {
+    div.mapped-removeGame {
       background-color: $surface0;
     }
   }
 
   #emoji-tab {
-    div[class*="emojiRemove-"] {
+    div.mapped-emojiRemove {
       background-color: $surface0;
     }
   }
 
   // Voice & Audio checks
-  section[class^="inputSensitivityToggle-"] {
-    div[class*="speaking-"] {
+  section.mapped-inputSensitivityToggle {
+    div.mapped-speaking {
       background: $green !important;
     }
   }
 
-  div[class*="reactionMe-"] {
+  div.mapped-reactionMe {
     background-color: $surface0 !important;
   }
 
   // toggles in preferencs
   // checked
-  div[class^="control-"] > div[class*="checked-"],
-  div[class^="sensitivity-"] div[class*="checked-"],
+  div.mapped-control > div.mapped-checked,
+  div.mapped-sensitivity div.mapped-checked,
   div[style*="background-color: hsl(139, calc(var(--saturation-factor, 1) * 47.3%), 43.9%)"] {
     background-color: $green !important;
 
-    // svg[class^="slider-"] {
+    // svg.mapped-slider {
     //     > rect {
     //         fill: $base;
     //     }
@@ -304,29 +304,29 @@ div[class^="contentRegion-"] {
   }
 
   // unchecked
-  div[class^="control"] {
+  div.mapped-control {
     > div[style*="background-color: hsl(218, calc(var(--saturation-factor, 1) * 4.6%), 46.9%)"] {
       background-color: $surface2 !important;
     }
 
-    svg[class^="slider-"] > svg > path {
+    svg.mapped-slider > svg > path {
       fill: darken($green, 40%) !important;
     }
   }
 
   // server boost page
   #guild_premium-tab {
-    [class*="tierAccomplished-"],
-    [class*="tierCurrent-"],
-    [class*="tierFirst-"] {
+    .mapped-tierAccomplished,
+    .mapped-tierCurrent,
+    .mapped-tierFirst {
       background: $pink;
     }
 
-    [class*="tierInProgress-"] {
+    .mapped-tierInProgress {
       background-color: $crust;
     }
 
-    div[class^="progressWithSubscriptions-"] > svg > g > rect {
+    div.mapped-progressWithSubscriptions > svg > g > rect {
       &:first-child {
         color: $crust;
       }
@@ -336,44 +336,44 @@ div[class^="contentRegion-"] {
       }
     }
 
-    div[class^="tierHeaderUnlocked-"],
-    div[class^="tierHeaderLocked-"] {
+    div.mapped-tierHeaderUnlocked,
+    div.mapped-tierHeaderLocked {
       background-color: $crust;
       color: $subtext0;
 
-      div[class^="tierUnlocked-"] {
+      div.mapped-tierUnlocked {
         background-image: linear-gradient(90deg, $blue, $mauve);
         color: $crust;
         font-weight: 600;
       }
 
-      svg[class^="tierIcon-"] {
+      svg.mapped-tierIcon {
         color: $pink;
       }
 
-      svg[class*="tierIconLocked-"] {
+      svg.mapped-tierIconLocked {
         color: $overlay1;
       }
 
-      svg[class^="tierLock-"] {
+      svg.mapped-tierLock {
         color: $surface2;
       }
     }
 
-    div[class^="tierBody-"] {
+    div.mapped-tierBody {
       color: $subtext1;
       background-color: $mantle;
     }
   }
 
   // active circles like the ones on server welcome screen settings
-  svg[class^="activeCircle-"] {
+  svg.mapped-activeCircle {
     color: $crust;
     background-color: $green;
   }
 
   #discovery-tab {
-    div[class*="checklistIcon"] svg {
+    div.mapped-checklistIcon svg {
       &[viewBox="0 0 14 14"] path {
         fill: $red;
       }
@@ -384,7 +384,7 @@ div[class^="contentRegion-"] {
   }
 
   #guild_templates-tab {
-    svg[class*="descriptionIcon"] {
+    svg.mapped-descriptionIcon {
       &[viewBox="0 0 24 24"] path {
         fill: $green;
       }
@@ -400,23 +400,23 @@ div[class^="contentRegion-"] {
   }
 
   #stickers-tab {
-    div[class*="tierHeaderContent"] {
+    div.mapped-tierHeaderContent {
       background-color: $crust;
     }
-    div[class*="tierBody"] {
+    div.mapped-tierBody {
       background-color: $mantle;
     }
   }
 
   #roles-tab {
-    div[class*="previewContainer-"] {
+    div.mapped-previewContainer {
       .theme-light {
-        img[class*="roleIcon-"] {
+        img.mapped-roleIcon {
           content: "data:image/svg+xml,%3Csvg width='20' height='20' viewBox='0 0 20 20' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M11.0749 1.66667H4.99996C3.15901 1.66667 1.66663 3.15906 1.66663 5.00001V15C1.66663 16.841 3.15901 18.3333 4.99996 18.3333H15C16.8409 18.3333 18.3333 16.841 18.3333 15V8.92511C17.8052 9.08227 17.2458 9.16667 16.6666 9.16667C13.445 9.16667 10.8333 6.555 10.8333 3.33334C10.8333 2.75419 10.9177 2.19476 11.0749 1.66667ZM6.66663 5.00001C7.58596 5.00001 8.33329 5.74601 8.33329 6.66667C8.33329 7.58801 7.58596 8.33334 6.66663 8.33334C5.74529 8.33334 4.99996 7.58801 4.99996 6.66667C4.99996 5.74601 5.74529 5.00001 6.66663 5.00001ZM4.99996 15L7.49996 11.6667L9.16663 13.3333L12.5 9.16667L15 15H4.99996Z' fill='%23#{str-slice(inspect($surface1), 2)}'/%3E%3Cpath d='M17.5 0V2.5H20V4.16667H17.5V6.66667H15.8334V4.16667H13.3334V2.5H15.8334V0H17.5Z' fill='%23#{str-slice(inspect($surface1), 2)}'/%3E%3C/svg%3E";
         }
       }
       .theme-dark {
-        img[class*="roleIcon-"] {
+        img.mapped-roleIcon {
           content: "data:image/svg+xml,%3Csvg fill='none' height='20' viewBox='0 0 20 20' width='20' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='%23#{str-slice(inspect($text), 2)}'%3E%3Cpath clip-rule='evenodd' d='m11.0749 1.66667h-6.07488c-1.84095 0-3.33333 1.49239-3.33333 3.33334v9.99999c0 1.841 1.49238 3.3333 3.33333 3.3333h9.99998c1.841 0 3.3334-1.4923 3.3334-3.3333v-6.07489c-.5281.15716-1.0876.24156-1.6667.24156-3.2217 0-5.8333-2.61167-5.8333-5.83333 0-.57915.0844-1.13858.2415-1.66667zm-4.40821 3.33334c.91933 0 1.66666.746 1.66666 1.66666 0 .92134-.74733 1.66667-1.66666 1.66667-.92134 0-1.66667-.74533-1.66667-1.66667 0-.92066.74533-1.66666 1.66667-1.66666zm-1.66667 9.99999 2.5-3.3333 1.66667 1.6666 3.33331-4.16663 2.5 5.83333z' fill-rule='evenodd'/%3E%3Cpath d='m17.5 0v2.5h2.5v1.66667h-2.5v2.5h-1.6667v-2.5h-2.5v-1.66667h2.5v-2.5z'/%3E%3C/g%3E%3C/svg%3E";
         }
       }
@@ -463,10 +463,10 @@ div[class^="contentRegion-"] {
   }
 }
 
-div[class^="perksModal"] {
+div.mapped-perksModal {
   background-color: $base;
 
-  li[class^="perk"] {
+  li.mapped-perk {
     background-color: $mantle;
 
     svg {
@@ -474,70 +474,70 @@ div[class^="perksModal"] {
     }
   }
 
-  svg[class^="giftIcon"] {
+  svg.mapped-giftIcon {
     color: $crust;
   }
 
-  div[class^="tierHeaderUnlocked"] {
+  div.mapped-tierHeaderUnlocked {
     background-image: linear-gradient(90deg, $blue, $mauve);
     color: $base;
   }
 
-  div[class^="tierUnlocked-"],
-  div[class^="tierMarkerBackground-"] {
+  div.mapped-tierUnlocked,
+  div.mapped-tierMarkerBackground {
     background-color: $base;
   }
 
-  div[class^="barBackground"],
-  div[class^="tierMarkerInProgress"],
-  div[class^="tierBody"] {
+  div.mapped-barBackground,
+  div.mapped-tierMarkerInProgress,
+  div.mapped-tierBody {
     background-color: $crust !important;
   }
 
-  div[class^="tierMarkerAccomplished"] {
+  div.mapped-tierMarkerAccomplished {
     background: $pink !important;
   }
 
-  div[class^="tierMarkerInProgress"] [class^="currentTierIcon"] {
+  div.mapped-tierMarkerInProgress .mapped-currentTierIcon {
     color: $pink;
   }
 
-  div[class^="barForeground"],
-  div[class^="tierMarkerAccomplished"] {
+  div.mapped-barForeground,
+  div.mapped-tierMarkerAccomplished {
     background-color: $pink;
   }
 
-  svg[class^="currentTierIcon"] {
+  svg.mapped-currentTierIcon {
     color: $base;
   }
 
-  div[class*="tierMarkerLabelText"],
-  svg[class^="tierLock"] {
+  div.mapped-tierMarkerLabelText,
+  svg.mapped-tierLock {
     color: var(--text-muted);
   }
 
-  div[class*="selectedTier"] div[class*="tierMarkerLabelText"] {
+  div.mapped-selectedTier div.mapped-tierMarkerLabelText {
     color: var(--text-normal);
   }
 
-  div[class^="tierHeaderLocked"] {
+  div.mapped-tierHeaderLocked {
     background-color: darken($crust, 5%);
     color: var(--text-muted);
   }
 
-  svg[class*="unlocked"] {
+  svg.mapped-unlocked {
     color: $green;
   }
 }
 
 // boost progress bar
-div[class^="sidebar-"] div[class^="container"] {
-  div[class^="progressBar-"] {
+div.mapped-sidebar div.mapped-container {
+  div.mapped-progressBar {
     background: linear-gradient(90deg, $blue, $mauve);
   }
 
   &:hover {
-    div[class^="progressBar-"] {
+    div.mapped-progressBar {
       background: linear-gradient(
         90deg,
         hsl(221, 70%, 55.5%),
@@ -548,57 +548,57 @@ div[class^="sidebar-"] div[class^="container"] {
     }
   }
 
-  div[class^="divider-"] {
+  div.mapped-divider {
     border-color: var(--background-modifier-accent);
   }
 }
 
-div[class^="pageWrapper-"] {
+div.mapped-pageWrapper {
   background: $base !important;
 
-  div[class*="searchBox-"] {
+  div.mapped-searchBox {
     background-color: $mantle;
 
-    svg[class*="clearIcon"] path {
+    svg.mapped-clearIcon path {
       fill: $overlay0;
     }
   }
 
-  div[class*="categoryPill-"][class*="selected-"] div {
+  div.mapped-categoryPill.mapped-selected div {
     color: $crust !important;
   }
 }
 
 // public server home
-div[class^="homeContainer-"] {
+div.mapped-homeContainer {
   background: $base !important;
 
-  > div[class^="homeContent-"] div[class*="card-"] {
+  > div.mapped-homeContent div.mapped-card {
     background: $surface0 !important;
   }
 }
 
 // the header for the public server home
-section[class^="title-"] {
+section.mapped-title {
   background: var(--background-primary) !important;
 }
 
-div[class^="categoryItem-"][class*="selectedCategoryItem"],
-button[class*="lookFilled"] div[class*="addButton"] {
+div.mapped-categoryItem.mapped-selectedCategoryItem,
+button.mapped-lookFilled div.mapped-addButton {
   // color when selected or if button
   color: $crust !important;
 }
 
 // new label
-div[class^="itemInner-"] div[class^="new-"] > div[class*="newText-"] {
+div.mapped-itemInner div.mapped-new > div.mapped-newText {
   color: $crust !important;
 }
 
 // app directory
-div[class*="directoryModal-"] {
+div.mapped-directoryModal {
   background-color: $base !important;
 
-  & [class*="searchBox"] {
+  & .mapped-searchBox {
     background-color: $mantle !important;
 
     & [name="search"]::placeholder {
@@ -606,18 +606,18 @@ div[class*="directoryModal-"] {
     }
   }
 
-  & [role="button"][class*="activeButton"] {
+  & [role="button"].mapped-activeButton {
     color: $crust;
   }
 }
 
 // student hubs
-section[class^="guildListSection-"] {
-  div[class^="guildList"]:first-child {
-    div[class^="iconContainer-"] {
+section.mapped-guildListSection {
+  div.mapped-guildList:first-child {
+    div.mapped-iconContainer {
       background-color: $green;
 
-      > div[class^="icon-"] {
+      > div.mapped-icon {
         background-image: url("data:image/svg+xml,%3Csvg fill='none' height='24' viewBox='0 0 25 24' width='25' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='%23#{str-slice(inspect($crust), 2)}'%3E%3Cpath clip-rule='evenodd' d='m13.25 18v-12h-1.5v12z' fill-rule='evenodd'/%3E%3Cpath clip-rule='evenodd' d='m7 12.75c-.69036 0-1.25.5596-1.25 1.25v4h-1.5v-4c0-1.5188 1.23122-2.75 2.75-2.75h11c1.5188 0 2.75 1.2312 2.75 2.75v4h-1.5v-4c0-.6904-.5596-1.25-1.25-1.25z' fill-rule='evenodd'/%3E%3Cpath d='m12.5 7c-1.3807 0-2.5-1.11929-2.5-2.5s1.1193-2.5 2.5-2.5 2.5 1.11929 2.5 2.5-1.1193 2.5-2.5 2.5z'/%3E%3Cpath d='m20 22c-1.3807 0-2.5-1.1193-2.5-2.5s1.1193-2.5 2.5-2.5 2.5 1.1193 2.5 2.5-1.1193 2.5-2.5 2.5z'/%3E%3Cpath d='m12.5 22c-1.3807 0-2.5-1.1193-2.5-2.5s1.1193-2.5 2.5-2.5 2.5 1.1193 2.5 2.5-1.1193 2.5-2.5 2.5z'/%3E%3Cpath d='m5 22c-1.38071 0-2.5-1.1193-2.5-2.5s1.11929-2.5 2.5-2.5 2.5 1.1193 2.5 2.5-1.11929 2.5-2.5 2.5z'/%3E%3C/g%3E%3C/svg%3E");
       }
     }
@@ -633,22 +633,22 @@ path[d="M17.225 6.06504C17.3227 6.00866 17.4362 5.98608 17.548 6.00084C17.6598 6
   fill: $crust;
 }
 
-div[class^="tierPreviews-"] {
-  button[class^="button-"] {
+div.mapped-tierPreviews {
+  button.mapped-button {
     background: linear-gradient(90deg, $teal, $blue);
   }
 }
 
-div[class^="notice-"] {
-  div[class*="header-"] {
+div.mapped-notice {
+  div.mapped-header {
     color: $crust;
   }
 
-  div[class^="closeButton-"] > svg > path {
+  div.mapped-closeButton > svg > path {
     fill: $crust;
   }
 
-  button[class^="button-"] {
+  button.mapped-button {
     border-color: $crust;
     color: $crust;
 

--- a/src/components/_pages.scss
+++ b/src/components/_pages.scss
@@ -177,7 +177,7 @@ div.mapped-contentRegion {
       color: $subtext1;
     }
 
-    .mapped-Divider {
+    .mapped-divider {
       border-color: var(--background-modifier-accent);
     }
 

--- a/src/components/_popouts.scss
+++ b/src/components/_popouts.scss
@@ -247,7 +247,7 @@ section.mapped-positionContainer {
     .mapped-roles,
     .mapped-defaultColor,
     .mapped-markup,
-    [class*="activityUserPopoutV2-"] *,
+    .mapped-activityUserPopoutV2 *,
     .mapped-customStatus,
     .mapped-section,
     .mapped-additionalActionsIcon,

--- a/src/components/_popouts.scss
+++ b/src/components/_popouts.scss
@@ -1,68 +1,70 @@
-div[class^="layerContainer"] [role="menu"] {
+div.mapped-layerContainer [role="menu"] {
   // make menu items readable when hovered
   --brand-experiment-560: var(--brand-experiment-25a);
   --brand-experiment-600: var(--brand-experiment);
 
-  [class*="colorDefault"] {
-    &[class*="colorBrand"] {
+  .mapped-colorDefault {
+    &.mapped-colorBrand {
       color: $brand;
     }
 
-    &[class*="focused"] {
-      &:not([class*="colorDanger"]),
-      [class*="checkbox-"] {
+    &.mapped-focused {
+      &:not(.mapped-colorDanger),
+      .mapped-checkbox {
         color: var(--interactive-normal);
       }
     }
 
-    &[role="menuitem"]:not([class*="colorDanger"]):not([id*="user-context-user-volume"]):hover {
+    &[role="menuitem"]:not(.mapped-colorDanger):not(
+        [id*="user-context-user-volume"]
+      ):hover {
       background: var(--background-accent);
       color: $crust;
 
-      [class*="subtext"],
-      [class*="caret-"] {
+      .mapped-subtext,
+      .mapped-caret {
         color: $crust;
       }
     }
 
-    [class*="caret"] {
+    .mapped-caret {
       color: $text;
     }
 
     // make active items have dark text
-    &:active:not([class*="hideInteraction-"]) {
+    &:active:not(.mapped-hideInteraction) {
       color: var(--background-floating);
 
-      [class*="check-"] {
+      .mapped-check {
         color: var(--interactive-normal);
       }
 
-      [class*="checkbox-"] {
+      .mapped-checkbox {
         color: var(--background-floating);
       }
     }
   }
 
   // make the switch account username crust when focused
-  [class*="focused"] [class*="userMenuUsername"] * {
+  .mapped-focused .mapped-userMenuUsername * {
     color: $crust;
   }
 
-  [class*="colorDanger"][class*="focused"],
-  [class*="colorDefault"] [class*="check-"] {
+  .mapped-colorDanger.mapped-focused,
+  .mapped-colorDefault .mapped-check {
     color: var(--background-floating);
     background-color: $red;
   }
 
   #guild-header-popout-premium-subscribe {
-    div[class^="iconContainer-"] > svg {
+    div.mapped-iconContainer > svg {
       color: $pink;
     }
   }
 
   // user volume slider
-  #user-context-user-volume div[class*="slider-"] {
-    div[class*="bar-"] {
+  #user-context-user-volume div.mapped-slider {
+    div.mapped-bar {
       background-color: $surface0;
     }
   }
@@ -70,19 +72,19 @@ div[class^="layerContainer"] [role="menu"] {
 
 .theme-dark,
 .theme-light {
-  div[class^="layerContainer"] div[id^="popout_"] > div[class*="didRender-"] {
-    &:not([class^="animatorBottom-"]) > div {
-      div[class*="flowerStarContainer-"] {
-        svg[class*="flowerStar-"] * {
+  div.mapped-layerContainer div[id^="popout_"] > div.mapped-didRender {
+    &:not(.mapped-animatorBottom) > div {
+      div.mapped-flowerStarContainer {
+        svg.mapped-flowerStar * {
           fill: $brand;
         }
       }
     }
-    div[class*="countText"] {
+    div.mapped-countText {
       color: $crust;
     }
 
-    svg[class*="activeIcon"] {
+    svg.mapped-activeIcon {
       circle {
         fill: $crust;
       }
@@ -91,8 +93,8 @@ div[class^="layerContainer"] [role="menu"] {
       }
     }
 
-    div[class*="container"] {
-      div[class*="autocompleteArrow-"],
+    div.mapped-container {
+      div.mapped-autocompleteArrow,
       header {
         background-color: $mantle;
       }
@@ -109,39 +111,39 @@ div[class^="layerContainer"] [role="menu"] {
   }
 }
 
-div[class*="recentMentionsPopout"] {
-  div[class^="header-"] {
-    div[class^="tabBar"] div[class^="tab"][class*="active-"] {
+div.mapped-recentMentionsPopout {
+  div.mapped-header {
+    div.mapped-tabBar div.mapped-tab.mapped-active {
       color: $base;
     }
 
-    div[class^="controls-"] {
+    div.mapped-controls {
       --background-secondary: #{$surface0};
       --background-primary: #{adjust-color($surface0, $alpha: -0.1)};
     }
   }
 
-  div[class^="scroller-"] {
+  div.mapped-scroller {
     [role="button"] {
       --background-tertiary: #{adjust-color($subtext0, $alpha: -0.85)};
       --background-floating: #{adjust-color($subtext0, $alpha: -0.88)};
 
-      div[class*="jumpButton-"] {
+      div.mapped-jumpButton {
         background-color: $surface0;
       }
     }
   }
 }
 
-div[class*="rolesList"] {
+div.mapped-rolesList {
   // make box lighter
-  div[class^="role-"],
-  button[class^="addButton-"] {
+  div.mapped-role,
+  button.mapped-addButton {
     background-color: lighten($mantle, 4%);
   }
 
-  div[class^="role-"] {
-    span[class^="roleCircle-"] {
+  div.mapped-role {
+    span.mapped-roleCircle {
       // default roles
       &[style*="background-color: rgb(185, 187, 190)"] {
         background-color: $subtext0 !important;
@@ -156,38 +158,38 @@ div[class*="rolesList"] {
   }
 }
 
-div[class*="layerContainer"] {
-  > div[class*="layer"] {
+div.mapped-layerContainer {
+  > div.mapped-layer {
     // reaction popout
-    div[class^="reactors"] {
+    div.mapped-reactors {
       background-color: var(--background-primary);
     }
 
     // the not selector should make it not style the user popouts
-    div[class^="scroller"]:not([style*="padding-right: 4px;"]) {
+    div.mapped-scroller:not([style*="padding-right: 4px;"]) {
       background-color: var(--background-secondary);
     }
 
-    div[class*="reactorDefault"] {
+    div.mapped-reactorDefault {
       -webkit-box-shadow: inset 0 -1px 0 var(--background-modifier-accent);
       box-shadow: inset 0 -1px 0 var(--background-modifier-accent);
     }
 
-    div[class*="reactionSelected"] {
+    div.mapped-reactionSelected {
       background-color: var(--background-modifier-selected);
     }
 
     // in DM -> select friends for group DM
-    div[class*="friendSelected"] {
+    div.mapped-friendSelected {
       background: $surface0 !important;
     }
   }
 }
 
 // gif/sticker/emoji section
-section[class^="positionContainer-"] {
+section.mapped-positionContainer {
   // colors tab when active
-  button[class*="navButtonActive"] {
+  button.mapped-navButtonActive {
     background-color: $brand;
     color: $crust;
   }
@@ -195,16 +197,16 @@ section[class^="positionContainer-"] {
 
 #emoji-picker-tab-panel {
   // more transparent to make things more bearable
-  [class*="stickerInspected-"] [class*="inspectedIndicator"],
-  [class^="emojiItem-"][class*="emojiItemSelected-"] {
+  .mapped-stickerInspected .mapped-inspectedIndicator,
+  .mapped-emojiItem.mapped-emojiItemSelected {
     background-color: var(--brand-experiment-25a);
   }
 
   // newly added thing
-  [class*="newlyAddedHighlight-"] {
+  .mapped-newlyAddedHighlight {
     border: 1px solid $green;
 
-    ~ [class*="newlyAddedBadge-"] {
+    ~ .mapped-newlyAddedBadge {
       background: $green !important;
       color: $crust;
     }
@@ -212,44 +214,44 @@ section[class^="positionContainer-"] {
 }
 
 // same as transparent above, but for stickers
-[class*="stickerInspected-"] [class^="inspectedIndicator"] {
+.mapped-stickerInspected .mapped-inspectedIndicator {
   background-color: var(--brand-experiment-25a);
 }
 
 .theme-light {
   //   color: $text;
 
-  > div[class^="focusLock"]
-    > div[class^="root"]
-    > div[class^="container"]
-    div[class*="footer"] {
+  > div.mapped-focusLock
+    > div.mapped-root
+    > div.mapped-container
+    div.mapped-footer {
     //     background-color: $mantle;
 
-    &[class*="footerSeparator-"] {
+    &.mapped-footerSeparator {
       box-shadow: inset 0 1px 0 $surface0;
       -webkit-box-shadow: inset 0 1px 0 $surface0;
     }
   }
 
-  > div[class^="focusLock"] > div[class^="root"] {
+  > div.mapped-focusLock > div.mapped-root {
     box-shadow: 0 0 0 1px $surface0,
       0 2px 10px 0 hsla(0, calc(var(--saturation-factor, 1) * 0%), 0%, 0.1);
     -webkit-box-shadow: 0 0 0 1px $surface0,
       0 2px 10px 0 hsla(0, calc(var(--saturation-factor, 1) * 0%), 0%, 0.1);
   }
 
-  &[class*="profileColors-"] {
-    [class*="userTagUsernameBase-"],
-    [class*="discrimBase-"],
-    [class*="title-"],
-    [class*="roles-"],
-    [class*="defaultColor-"],
-    [class*="markup-"],
+  &.mapped-profileColors {
+    .mapped-userTagUsernameBase,
+    .mapped-discrimBase,
+    .mapped-title,
+    .mapped-roles,
+    .mapped-defaultColor,
+    .mapped-markup,
     [class*="activityUserPopoutV2-"] *,
-    [class*="customStatus-"],
-    [class*="section-"],
-    [class*="additionalActionsIcon-"],
-    [class*="overlayBackground-"] * {
+    .mapped-customStatus,
+    .mapped-section,
+    .mapped-additionalActionsIcon,
+    .mapped-overlayBackground * {
       --interactive-normal: #{$crust};
       --text-normal: #{$crust};
       --interactive-active: #{$crust};
@@ -259,7 +261,7 @@ section[class^="positionContainer-"] {
   }
 }
 
-div[class^="layerContainer"] {
+div.mapped-layerContainer {
   // right-click popups for guild, channels, and user
   #guild-header-popout,
   #guild-context,
@@ -268,7 +270,7 @@ div[class^="layerContainer"] {
     background: $crust;
   }
 
-  > div[class*="layer"] {
+  > div.mapped-layer {
     // search popout
     div[role="listbox"] {
       background-color: $mantle;
@@ -278,12 +280,12 @@ div[class^="layerContainer"] {
           background: $surface0;
         }
 
-        svg[class*="selectedIcon"] circle {
+        svg.mapped-selectedIcon circle {
           fill: $crust;
         }
       }
 
-      div[class*="queryText-"] {
+      div.mapped-queryText {
         color: $overlay1;
         strong {
           color: $text;
@@ -291,11 +293,11 @@ div[class^="layerContainer"] {
       }
     }
 
-    div[class^="focusLock"] {
+    div.mapped-focusLock {
       // create channel (modal), stream popout (modalSize) and edit attachment (uploadModal)
-      div[class^="modal-"],
-      div[class^="modalSize-"],
-      div[class^="uploadModal-"] {
+      div.mapped-modal,
+      div.mapped-modalSize,
+      div.mapped-uploadModal {
         background-color: $mantle;
         li,
         p,
@@ -305,14 +307,14 @@ div[class^="layerContainer"] {
       }
 
       // their respective footers
-      div[class*="footer"] {
+      div.mapped-footer {
         background-color: $crust;
 
         button[type="submit"] span {
           color: $crust;
         }
 
-        [class*="footerText-"] {
+        .mapped-footerText {
           color: $subtext1;
         }
       }
@@ -324,7 +326,7 @@ div[class^="layerContainer"] {
       h4,
       h5,
       h6 {
-        &[class^="fixed-"] {
+        &.mapped-fixed {
           &:after {
             background-color: $red;
           }
@@ -332,25 +334,25 @@ div[class^="layerContainer"] {
         }
       }
 
-      div[class*="message-"] {
+      div.mapped-message {
         background-color: $surface0;
       }
 
       &[aria-label="Activities"] {
-        div[class*="activityItem-"] {
+        div.mapped-activityItem {
           background-color: $crust;
 
-          div[class*="previewBadge-"] {
+          div.mapped-previewBadge {
             color: $crust;
           }
         }
-        div[class*="activityTag-"] {
+        div.mapped-activityTag {
           background-color: $surface0;
         }
       }
 
       &[aria-label="Manage Accounts"] {
-        div[class*="navRow-"] {
+        div.mapped-navRow {
           background-color: $mantle;
         }
       }
@@ -358,38 +360,38 @@ div[class^="layerContainer"] {
   }
 
   // add game
-  div[class^="addGamePopout-"] {
+  div.mapped-addGamePopout {
     background-color: $mantle;
   }
 
-  div[class*="searchOption-"]::after,
-  div[class*="option-"]::after,
-  li[class*="option-"]::after {
+  div.mapped-searchOption::after,
+  div.mapped-option::after,
+  li.mapped-option::after {
     display: none;
   }
 
-  div[class^="queryContainer"] {
+  div.mapped-queryContainer {
     background-color: $crust;
-    span[class^="key"] {
+    span.mapped-key {
       color: $text;
       background-color: $base;
     }
   }
 
   // branded and colored tooltips should have dark text
-  [class*="tooltipBrand-"],
-  [class*="tooltipRed-"],
-  [class*="tooltipGreen-"],
-  [class*="tooltipYellow"] {
+  .mapped-tooltipBrand,
+  .mapped-tooltipRed,
+  .mapped-tooltipGreen,
+  .mapped-tooltipYellow {
     color: $crust;
   }
 
   // when hovering active threads
-  div[class^="popout-"] div[class^="row"][role="button"] {
+  div.mapped-popout div.mapped-row[role="button"] {
     &:hover {
       color: $crust;
 
-      [class*="timestamp"] {
+      .mapped-timestamp {
         color: $crust;
       }
     }
@@ -397,19 +399,19 @@ div[class^="layerContainer"] {
 }
 
 // add account modal + cards
-form[class*="card-"] {
+form.mapped-card {
   background-color: $base;
 }
 
 // user info
-div[class*="userInfoSection-"] {
-  div[class^="connectedAccountContainer-"] {
+div.mapped-userInfoSection {
+  div.mapped-connectedAccountContainer {
     background-color: adjust-color($surface0, $alpha: -0.55) !important;
   }
 }
 
 // Warning card popouts ex. admin change username/account deletion
-div[class*="cardWarning-"] div[class*="warning-"] {
+div.mapped-cardWarning div.mapped-warning {
   color: $crust;
 }
 
@@ -418,14 +420,14 @@ div[class*="cardWarning-"] div[class*="warning-"] {
 #sticker-picker-tab-panel {
   /* --background-floating: #{$surface0};
 
-  + div[class^="slotsContainer-"] {
+  + div.mapped-slotsContainer {
     background-color: $surface0;
   }
 */
 
-  div[class^="tooltipContainer-"] {
-    label[class^="label-"] {
-      &[class*="labelChecked-"] {
+  div.mapped-tooltipContainer {
+    label.mapped-label {
+      &.mapped-labelChecked {
         background: -webkit-gradient(
           linear,
           right top,
@@ -453,10 +455,10 @@ div[class*="cardWarning-"] div[class*="warning-"] {
   }
 }
 
-div[class*="keyboardShortcutsModal-"] {
+div.mapped-keyboardShortcutsModal {
   background-color: $mantle !important;
 
-  div[class^="keybindShortcut-"] span[class^="key-"] {
+  div.mapped-keybindShortcut span.mapped-key {
     color: $crust;
 
     svg g {
@@ -479,13 +481,13 @@ div[class*="keyboardShortcutsModal-"] {
 .react-datepicker__day--selected:after {
   background-color: $blue !important;
 }
-[class^="datePickerHint-"] [class^="hintValue-"] {
+.mapped-datePickerHint .mapped-hintValue {
   color: $crust !important;
 }
 
-div[class*="layerContainer-"] {
-  div[class^="control-"] {
-    div[class*="checked-"] {
+div.mapped-layerContainer {
+  div.mapped-control {
+    div.mapped-checked {
       background-color: $green !important;
     }
     div[style*="background-color: rgb(114, 118, 125);"] {
@@ -494,18 +496,18 @@ div[class*="layerContainer-"] {
   }
 }
 
-div[class*="layerContainer-"] {
-  div[class*="guildPopout-"][role="dialog"] {
+div.mapped-layerContainer {
+  div.mapped-guildPopout[role="dialog"] {
     background-color: $base;
 
-    div[class*="guildName-"] {
+    div.mapped-guildName {
       color: $text;
     }
   }
 }
 
-div[class*="layerContainer-"] [role*="dialog"] {
-  a[class*="downloadLink-"] {
+div.mapped-layerContainer [role*="dialog"] {
+  a.mapped-downloadLink {
     color: $overlay1 !important;
     opacity: 1;
     &:hover {
@@ -514,8 +516,8 @@ div[class*="layerContainer-"] [role*="dialog"] {
   }
 }
 
-div[class*="userPopoutOuter-"],
-div[class*="userProfileOuter-"] {
+div.mapped-userPopoutOuter,
+div.mapped-userProfileOuter {
   div[aria-label="HypeSquad Bravery"] img {
     content: url("data:image/svg+xml,%3Csvg height='24' viewBox='0 0 24 24' width='24' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath clip-rule='evenodd' d='m5.01502 4h13.97008c.1187 0 .215.09992.215.22305v9.97865c0 .0697-.0312.1343-.0837.1767l-6.985 5.5752c-.0389.0313-.0847.0464-.1314.0464-.0466 0-.0924-.0151-.1313-.0464l-6.985-5.5752c-.05252-.0424-.08365-.107-.08365-.1767v-9.97865c0-.12313.0963-.22305.21497-.22305zm7.82148 7.0972 4.1275-2.71296c.1039-.06863.2299.04542.1725.15644l-1.7114 3.36192c-.0403.0807.0182.1756.1079.1756h1.0246c.118 0 .1664.1504.0706.219l-4.6267 3.3175c-.0414.0303-.0978.0303-.1402 0l-4.6267-3.3175c-.0948-.0686-.04639-.219.07059-.219h1.02356c.09076 0 .14925-.0949.10791-.1756l-1.71132-3.36293c-.05648-.11001.06958-.22305.17345-.15543l4.12851 2.71296c.0716.0474.1291.112.1674.1887l.6293 1.2636c.0444.0888.1714.0888.2158 0l.6293-1.2636c.0383-.0767.0958-.1423.1674-.1887z' fill='%23#{str-slice(inspect($mauve), 2)}' fill-rule='evenodd'/%3E%3C/svg%3E");
   }
@@ -531,24 +533,24 @@ div[class*="userProfileOuter-"] {
   div[aria-label="Early Verified Bot Developer"] {
     content: url("data:image/svg+xml,%3Csvg height='24' viewBox='0 0 24 24' width='24' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='m21.58 11.4-4.28-7.39-.35-.6h-9.91l-.35.6-4.27 7.39-.35.6.35.6 4.27 7.39.35.6h9.92l.35-.6 4.28-7.39.35-.6zm-13.07-1.03-1.63 1.63 1.63 1.63v2.73l-4.36-4.36 4.37-4.37v2.74zm3.12 6.93-2.04-.63 3.1-9.98 2.04.64zm3.86-.93v-2.73l1.63-1.64-1.63-1.63v-2.74l4.36 4.37z' fill='%23#{str-slice(inspect($blue), 2)}'/%3E%3C/svg%3E");
   }
-  div[class^="userPopoutOverlayBackground"]
-    > div[class^="scroller"]
-    > div[class^="section"]:first-child
-    > div[class^="buttonsContainer"]
+  div.mapped-userPopoutOverlayBackground
+    > div.mapped-scroller
+    > div.mapped-section:first-child
+    > div.mapped-buttonsContainer
     > button:nth-child(2) {
     background: $brand;
   }
 }
 
-[class*="layerContainer-"] [class*="toolbar-"] {
+.mapped-layerContainer .mapped-toolbar {
   background-color: var(--background-floating);
 
-  [class*="buttons-"] [class*="icon-"] {
+  .mapped-buttons .mapped-icon {
     color: $text;
   }
 }
 
-[class*="layerContainer-"] div[id="sort-and-view"] {
+.mapped-layerContainer div[id="sort-and-view"] {
   div[id="sort-and-view-reset-all"] [style="color: var(--text-normal);"]:hover {
     color: $crust !important;
   }

--- a/src/components/_sidebar.scss
+++ b/src/components/_sidebar.scss
@@ -1,9 +1,9 @@
 // "spine" svgs before threads
-svg[class^="spine-"] {
+svg.mapped-spine {
   color: $surface2;
 }
 
-div[class^="spineBorder-"] {
+div.mapped-spineBorder {
   background: $surface2;
 }
 
@@ -45,21 +45,21 @@ ul[aria-label$=" threads"] > li:nth-child(6n) {
 }
 
 // bot tag in sidebar
-[class^="botText"] {
+.mapped-botText {
   color: $crust;
   font-weight: 600;
 }
 
-svg[class^="botTagVerified"] {
+svg.mapped-botTagVerified {
   color: $crust;
 }
 
-div[class*="activePostCount-"] {
+div.mapped-activePostCount {
   background-color: $surface0;
   color: $text !important;
 }
 
-div[class*="newPostCount-"] {
+div.mapped-newPostCount {
   background-color: $text;
   color: $crust;
 }

--- a/src/components/_variables.scss
+++ b/src/components/_variables.scss
@@ -279,16 +279,16 @@ html {
   --interactive-active: #{$text};
 
   // make tooltips that you can't hover surface0
-  [class*="disabledPointerEvents"] {
+  .mapped-disabledPointerEvents {
     --background-floating: #{$surface0};
     --background-tertiary: #{lighten($base, 3%)};
 
-    svg[class^="activityIcon-"] {
+    svg.mapped-activityIcon {
       color: $subtext0;
     }
 
-    [class*="tooltipBrand-"] {
-      [class*="tooltipText-"] {
+    .mapped-tooltipBrand {
+      .mapped-tooltipText {
         color: $crust;
       }
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -380,6 +380,13 @@ onetime@^6.0.0:
   dependencies:
     mimic-fn "^4.0.0"
 
+p-limit@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-4.0.0.tgz#914af6544ed32bfa54670b061cafcbd04984b644"
+  integrity sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==
+  dependencies:
+    yocto-queue "^1.0.0"
+
 p-map@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/p-map/-/p-map-4.0.0.tgz#bb2f95a5eda2ec168ec9274e06a747c3e2904d2b"
@@ -589,3 +596,8 @@ yaml@^2.1.3:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.2.1.tgz#3014bf0482dcd15147aa8e56109ce8632cd60ce4"
   integrity sha512-e0WHiYql7+9wr4cWMx3TVQrNwejKaEe7/rHNmQmqRjazfOP5W8PB6Jpebb5o6fIapbz9o9+2ipcaTM2ZwDI6lw==
+
+yocto-queue@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-1.0.0.tgz#7f816433fb2cbc511ec8bf7d263c3b58a1a3c251"
+  integrity sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==


### PR DESCRIPTION
This PR fetches the source CSS from Discord and replaces `.mapped-*` class names in the theme CSS with the upstream classes instead of matching with `class` attributes, because attribute selectors are very slow compared to class ones.

## Pros

- Improves code readability
- Checks for nonexistent class names
- Up to 1.6x rendering speedup on a high-end laptop

<img width="168" alt="Before: 278ms Rendering" src="https://user-images.githubusercontent.com/70191398/226103058-b2984e7f-bba7-4798-be92-0607f59f28e7.png"> <img width="166" alt="After: 172ms Rendering" src="https://user-images.githubusercontent.com/70191398/226103068-6fb881f3-7d64-442d-a9ec-798404862a08.png">

## Cons

- May take a few minutes to update