### PR TITLE
fix: empty thread message error border

### DIFF
--- a/src/components/_chat.scss
+++ b/src/components/_chat.scss
@@ -245,6 +245,11 @@ div[class^="chat"]
   background-color: var(--background-secondary);
 }
 
+// fix error border when attempting to start a thread with no message
+[class*="channelTextAreaInnerError-"] {
+  border: 1px solid #f38ba8 !important;
+}
+
 // calls
 div[class^="callContainer-"] {
   [class*="controlIcon-"] {


### PR DESCRIPTION
Incorrect
![image](https://user-images.githubusercontent.com/53945697/229859478-a7b92efb-fc4f-4d86-b166-c6a7acbcde96.png)

Correct
![image](https://user-images.githubusercontent.com/53945697/229859566-8ed303a3-692a-4247-9993-5981bf776df7.png)
