### PR TITLE
fix: prevent style leaking to user popout

### DIFF
--- a/src/components/_popouts.scss
+++ b/src/components/_popouts.scss
@@ -166,7 +166,7 @@ div[class*="layerContainer"] {
     }
 
     // the not selector should make it not style the user popouts
-    div[class^="scroller"]:not([style*="padding-right: 4px;"]) {
+    div[class^="scroller"]:not([style*="padding-right: 4px;"], [style*="padding-right: 8px;"]) {
       background-color: var(--background-secondary);
     }
 


### PR DESCRIPTION
Before:
<img width="326" alt="image" src="https://user-images.githubusercontent.com/102488279/230176923-6a74c81a-db56-498d-92a2-bd09060f2c7c.png">
After:
<img width="320" alt="image" src="https://user-images.githubusercontent.com/102488279/230176971-3fc906b7-998a-4360-ab74-93ab33b88b4c.png">
