### PR TITLE
fix: unthemed browser client download popout

### DIFF
--- a/src/components/_popouts.scss
+++ b/src/components/_popouts.scss
@@ -248,6 +248,33 @@ section[class^="positionContainer-"] {
       0 2px 10px 0 hsla(0, calc(var(--saturation-factor, 1) * 0%), 0%, 0.1);
   }
 
+  // browser-only download client popout
+  div[class|="focusLock"] div[class|="downloadApps"] {
+    background-color: $base !important;
+
+    button[class|="modalCloseButton"],
+    h2,
+    h3 {
+      color: $text;
+    }
+
+    div[class*="footer-"] {
+      color: $text !important;
+      background-color: unset !important;
+
+      a {
+        color: $blue;
+      }
+    }
+
+    li[class*="active-"] {
+      a[class*="downloadButton-"] {
+        transition: all 0.3s ease-in-out;
+        color: $base;
+      }
+    }
+  }
+
   &[class*="profileColors-"] {
     [class*="userTagUsernameBase-"],
     [class*="discrimBase-"],


### PR DESCRIPTION
On browser, there is a button at the bottom of the server scroller that opens a menu that was pretty much only themed by some residual css. Unfortunately, the svg images are loaded via css, and not embedded in the html. This means without recoloring and hosting the svgs (which is likely against some license) they must remain the colors they are.

Before: 
![image](https://github.com/catppuccin/discord/assets/53945697/e7fe746c-e5e4-49e5-9a49-95dff239b2dd)

After:
![image](https://github.com/catppuccin/discord/assets/53945697/90ee77da-cb1b-4494-8666-5cf98654ecb6)
