### PR TITLE
fix: Channels & Roles text badge

### DIFF
--- a/src/components/_details.scss
+++ b/src/components/_details.scss
@@ -194,9 +194,15 @@ div[class*="unreadBar-"] {
 }
 
 // make number badges have crust text and bolder
-div[class*="numberBadge-"] {
+div[class|="numberBadge"] {
   font-weight: 700;
   color: $crust;
+}
+
+// Channel and role badge
+div[class|="newChannel"] {
+  color: $crust;
+  background-color: $brand;
 }
 
 // spotify button on text area

--- a/src/components/_popouts.scss
+++ b/src/components/_popouts.scss
@@ -248,6 +248,33 @@ section[class^="positionContainer-"] {
       0 2px 10px 0 hsla(0, calc(var(--saturation-factor, 1) * 0%), 0%, 0.1);
   }
 
+  // browser-only download client popout
+  div[class|="focusLock"] div[class|="downloadApps"] {
+    background-color: $base !important;
+
+    button[class|="modalCloseButton"],
+    h2,
+    h3 {
+      color: $text;
+    }
+
+    div[class*="footer-"] {
+      color: $text !important;
+      background-color: unset !important;
+
+      a {
+        color: $blue;
+      }
+    }
+
+    li[class*="active-"] {
+      a[class*="downloadButton-"] {
+        transition: all 0.3s ease-in-out;
+        color: $base;
+      }
+    }
+  }
+
   &[class*="profileColors-"] {
     [class*="userTagUsernameBase-"],
     [class*="discrimBase-"],


### PR DESCRIPTION
Before:
![image](https://github.com/catppuccin/discord/assets/53945697/60702c54-5eb0-46a6-ab92-1aecfdf22182)

After:
![image](https://github.com/catppuccin/discord/assets/53945697/7b5ea77a-b52f-4a26-85be-b2f454be6dac)

I Also noticed while I was working it out that the Number badge directly above it could use the `|=` selector as well so figured I'd just lump it in :3