### PR TITLE
fix: Clyde AI bot tag

### DIFF
--- a/src/components/_details.scss
+++ b/src/components/_details.scss
@@ -205,6 +205,11 @@ div[class|="newChannel"] {
   background-color: $brand;
 }
 
+// Clyde AI Bot tag
+div[class|="botTag"] {
+  background-color: $brand;
+}
+
 // spotify button on text area
 button[class^="attachButton-"] {
   svg path[class^="attachButtonPlay-"] {


### PR DESCRIPTION
![image](https://github.com/catppuccin/discord/assets/53945697/384923dc-e3fd-4a53-adec-dd2c5ffd4a04)

Follows accent color as it should to match other bot tags :>