### PR TITLE
fix: Add Friend input box border should use accent

### DIFF
--- a/src/components/_details.scss
+++ b/src/components/_details.scss
@@ -116,9 +116,7 @@ div[class*="flowerStarContainer-"] {
   }
 
   &[class*="iconBackgroundTierOne-"],
-  &[class*="iconBackgroundTierTwo-"]:not(
-      [class*="boostedGuildTierIconBackgroundWithVisibleBanner"]
-    ) {
+  &[class*="iconBackgroundTierTwo-"]:not([class*="boostedGuildTierIconBackgroundWithVisibleBanner"]) {
     svg[class*="flowerStar-"] * {
       fill: $surface2;
     }
@@ -210,6 +208,11 @@ div[class|="botTag"] {
   background-color: $brand;
 }
 
+// Add Friend text box border on selection should use accent
+div[class|="addFriendInputWrapper"]:focus-within {
+  border-color: $brand;
+}
+
 // spotify button on text area
 button[class^="attachButton-"] {
   svg path[class^="attachButtonPlay-"] {
@@ -260,9 +263,6 @@ div[class*="tryItOutBadge-"] {
 }
 
 span[class*="channelMention"]:hover,
-[class*="mention"]:not(
-    [class*="mentionButton-"],
-    [class*="mentionIcon-"]
-  ):hover {
+[class*="mention"]:not([class*="mentionButton-"], [class*="mentionIcon-"]):hover {
   color: $crust;
 }


### PR DESCRIPTION
Current
![image](https://github.com/catppuccin/discord/assets/53945697/7c2691e9-5dfd-4b9c-a3ab-d344d6a05510)

After
![image](https://github.com/catppuccin/discord/assets/53945697/afd40179-84f2-438a-9e63-1afd4c30e85c)
