### PR TITLE
fix: vencord theme input border should use accent

### DIFF
--- a/src/components/_details.scss
+++ b/src/components/_details.scss
@@ -87,6 +87,11 @@ rect[fill="#593695"] {
   padding: 16px;
 }
 
+// Vencord theme input border should use accent
+#vencordthemes-tab [class*="input-"]:focus {
+  border-color: $brand !important;
+}
+
 // dots in typing
 svg[class^="cursorDefault-"] svg[class^="dots-"] circle {
   fill: $base !important;


### PR DESCRIPTION
Before
![image](https://github.com/catppuccin/discord/assets/53945697/1185b872-3e30-45eb-a5de-674c149418ad)

After
![image](https://github.com/catppuccin/discord/assets/53945697/e183161d-6e1f-40bf-85d6-1de4a5a63617)
