### PR TITLE
fix: New Channel badge has wrong background

### DIFF
--- a/src/components/_details.scss
+++ b/src/components/_details.scss
@@ -205,7 +205,7 @@ div[class|="numberBadge"] {
 // Channel and role badge
 div[class|="newChannel"] {
   color: $crust;
-  background-color: $brand;
+  background-color: $brand !important;
 }
 
 // Clyde AI Bot tag


### PR DESCRIPTION
Because of *course* they changed it into an inline style!