### PR TITLE
fix: Pending friend request badge button

### DIFF
--- a/src/components/_details.scss
+++ b/src/components/_details.scss
@@ -267,6 +267,11 @@ div[class*="tryItOutBadge-"] {
   color: $crust;
 }
 
+// Pending Friend Request alert badge
+[class|="tabBar"] [class|="badge"] {
+  color: #11111b;
+}
+
 span[class*="channelMention"]:hover,
 [class*="mention"]:not([class*="mentionButton-"], [class*="mentionIcon-"]):hover {
   color: $crust;


### PR DESCRIPTION
![image](https://github.com/catppuccin/discord/assets/53945697/6a5ff37c-1e1d-4e45-9e49-0cfedac03856)
Proof catppuccin users don't have friends that this hadn't been found yet :woeis: