### PR TITLE
fix: Call buttons are the wrong color

### DIFF
--- a/src/components/_chat.scss
+++ b/src/components/_chat.scss
@@ -401,6 +401,14 @@ div[class|="callContainer"] {
         }
       }
 
+      &[class*="green-"] {
+        background: $green;
+
+        [class*="centerIcon-"] {
+          color: $crust;
+        }
+      }
+
       &[class*="white-"] {
         color: $crust;
         background-color: $subtext1;


### PR DESCRIPTION
before
![image](https://github.com/catppuccin/discord/assets/53945697/89c77952-5ea0-4889-adc1-fd720b2cd21a)

after 
![image](https://github.com/catppuccin/discord/assets/53945697/22d07c1f-6e18-4aa3-b4bd-e6e5bb946180)
