### PR TITLE
fix: navbar elements text color on `:hover` and active

### DIFF
--- a/src/components/_navbar.scss
+++ b/src/components/_navbar.scss
@@ -1,6 +1,6 @@
 nav[class*="guilds-"] {
   // server icons
-  foreignObject > div[data-list-item-id|="guildsnav_"] {
+  foreignObject > div[data-list-item-id*="guildsnav_"] {
     background-color: lighten($base, 2%);
 
     &:hover,
@@ -26,10 +26,14 @@ nav[class*="guilds-"] {
   }
 
   // create server/discovery
-  div[data-list-item-id="guildsnav___create-join-button"] svg > path,
-  div[data-list-item-id="guildsnav___guild-discover-button"] svg > path,
-  div[data-list-item-id="guildsnav___app-download-button"] svg > path {
-    fill: $green;
+  div[data-list-item-id="guildsnav___create-join-button"],
+  div[data-list-item-id="guildsnav___guild-discover-button"],
+  div[data-list-item-id="guildsnav___app-download-button"] {
+    &:hover,
+    &[class*="selected"] {
+      color: $crust;
+      font-weight: 600;
+    }
   }
 }
 


### PR DESCRIPTION
fixes navbar elements illegible text on hover and active

before:
![image](https://github.com/catppuccin/discord/assets/66728045/99409ac0-63c0-4481-961c-8c4691cf3510)

after:
![image](https://github.com/catppuccin/discord/assets/66728045/d196b8f9-e8ec-43ee-b2a0-089997737dc6)

