### PR TITLE
fix: navbar elements background on `:hover`

### DIFF
--- a/src/components/_navbar.scss
+++ b/src/components/_navbar.scss
@@ -1,8 +1,6 @@
 nav[class*="guilds-"] {
   // server icons
   foreignObject > div[data-list-item-id*="guildsnav_"] {
-    background-color: lighten($base, 2%);
-
     &:hover,
     &[class*="selected"] {
       > div[class|="childWrapper"] {


### PR DESCRIPTION
before:
![Screenshot_2023-09-19-11-15-58](https://github.com/catppuccin/discord/assets/66728045/6b11d943-a422-4e9d-b1c5-b0c6b18342b4)

after:
![Screenshot_2023-09-19-11-18-16](https://github.com/catppuccin/discord/assets/66728045/a40f40f5-e284-451c-9df5-e8a025c0a832)

should fix:
1. add a server
2. explore discoverable servers
3. download apps

small oof, forgot to delete this line last time