### PR TITLE
fix: active RPC game toggle icons uncolored

### DIFF
--- a/src/components/_pages.scss
+++ b/src/components/_pages.scss
@@ -240,8 +240,8 @@ div[class|="contentRegion"] {
     div[class*="activeGame-"][class*="nowPlaying"] * {
       color: $crust;
 
-      svg > g > path {
-        fill: $crust;
+      svg > path {
+        fill: $crust !important;
       }
     }
 


### PR DESCRIPTION
Discord try not to randomly remove an element in an svg challenge (impossible)

Before
![image](https://github.com/catppuccin/discord/assets/53945697/1c660472-e4a8-4bf6-87b9-3d588513e793)

After
![image](https://github.com/catppuccin/discord/assets/53945697/69fa48e8-3a49-4c64-b330-3a30fb65a161)
