### PR TITLE
fix: A lot of stage channel bugs & the account switcher

### DIFF
--- a/src/components/_buttons.scss
+++ b/src/components/_buttons.scss
@@ -29,6 +29,11 @@
   }
 }
 
+// For some reason, red buttons on click turn blue. Sure.
+button[class*="lookFilled-"][class*="colorRed-"]:active {
+  background-color: $red;
+}
+
 [class*="lookOutlined-"][class*="colorPrimary-"] {
   border-color: $surface1;
 

--- a/src/components/_chat.scss
+++ b/src/components/_chat.scss
@@ -455,6 +455,14 @@ div[class|="callContainer"] {
   }
 }
 
+// Weird gradient thing on forums
+div[class|="chat"]
+  section[class*="forumOrHome-"]
+  div[class|="upperContainer"]
+  > div[class|="children"]:after {
+  background: none;
+}
+
 // gifts
 div[class*="giftCodeContainer"] [class*="tile"] {
   background-color: $mantle;

--- a/src/components/_chat.scss
+++ b/src/components/_chat.scss
@@ -424,6 +424,10 @@ div[class|="callContainer"] {
         [class*="centerIcon-"] {
           color: $text;
         }
+
+        svg[class|="raisedHandButtonIcon"] {
+          color: $text;
+        }
       }
 
       &[class*="green-"] {

--- a/src/components/_chat.scss
+++ b/src/components/_chat.scss
@@ -369,6 +369,13 @@ div[class|="callContainer"] {
       }
     }
 
+    div[class|="bottomControls"] {
+      button[class|="textButton"] {
+        color: $text;
+        background-color: $surface1;
+      }
+    }
+
     div[class|="toolbar"] {
       svg[class|="controlIcon"] {
         color: var(--interactive-normal);

--- a/src/components/_popouts.scss
+++ b/src/components/_popouts.scss
@@ -45,9 +45,31 @@ div[class|="layerContainer"] [role="menu"] {
     }
   }
 
-  // make the switch account username crust when focused
-  [class*="focused"] [class*="userMenuUsername"] * {
-    color: $crust;
+  // Account switcher submenu
+  div[id|="account-switch-account"] {
+    &[class*="focused"] {
+      div[class*="userMenuUsername"] div {
+        color: $crust;
+      }
+
+      svg[class|="activeIcon"] {
+        circle {
+          fill: $blue;
+        }
+        g path {
+          fill: $crust;
+        }
+      }
+    }
+
+    svg[class|="activeIcon"] {
+      circle {
+        fill: $crust;
+      }
+      g path {
+        fill: $blue;
+      }
+    }
   }
 
   [class*="colorDanger"][class*="focused"],


### PR DESCRIPTION
As the Discord dev, I toil and I strive,
Fixing bugs so they won't come alive.
But they keep coming back,
Like a never-ending track,
And my sanity, I fear, takes a dive.

## Account Switcher:
Before:
![image](https://github.com/catppuccin/discord/assets/53945697/df929d1b-70b3-4bd3-af34-884655ee71bd)

After:
![image](https://github.com/catppuccin/discord/assets/53945697/c2f6735c-a25d-41a4-a1fb-9127629ab19a)

## Stage channel Invite:
Before:
![image](https://github.com/catppuccin/discord/assets/53945697/be3f9088-5c34-48f6-bf58-cb3a4399f87f)

After:
![image](https://github.com/catppuccin/discord/assets/53945697/28cb0074-625f-41a7-aae8-b28540948d45)

## Raised Hand button:
Before:
![image](https://github.com/catppuccin/discord/assets/53945697/c5ff6c8d-9463-43bf-99bb-38426924955a)

After:
![image](https://github.com/catppuccin/discord/assets/53945697/3893bb42-d9e9-46a4-b606-ec2302f66d43)

## Strange Gradient:
Before:
![image](https://github.com/catppuccin/discord/assets/53945697/d2c8acff-f7ea-46db-88fb-ede2cd8e6e1a)

After:
![image](https://github.com/catppuccin/discord/assets/53945697/70b0eda1-7b2f-4704-b49b-d7765b8f212f)

## Red turns blue:
Before:
![image](https://github.com/catppuccin/discord/assets/53945697/4e4f3267-a3ea-410e-b95a-0b2aaa98de79)

After:
![image](https://github.com/catppuccin/discord/assets/53945697/5e03b286-c51c-4b04-815b-7bab130b992b)
