### PR TITLE
fix: nitro profile picture upsell button

### DIFF
--- a/src/components/_pages.scss
+++ b/src/components/_pages.scss
@@ -432,6 +432,12 @@ div[class|="contentRegion"] {
       color: $crust;
     }
   }
+
+  #profile-customization-tab {
+    div[class*="premiumFeatureBannerBackground"] button {
+      color: $crust;
+    }
+  }
 }
 
 .bd-settings-title {


### PR DESCRIPTION
And one more of tnixc's bugs for the road
i'm tired
![image](https://github.com/catppuccin/discord/assets/53945697/3a54e131-ada4-4f4b-8dc7-103fac37d0ea)
here's what it looked like before, now it actually looks right
idk breaking the embeds spooked me so now i'm just <a:KEK:1102995183739613224>