### PR TITLE
fix: Keybinds popout text

### DIFF
--- a/src/components/_popouts.scss
+++ b/src/components/_popouts.scss
@@ -649,3 +649,12 @@ div[class|="layerContainer"] div[class|="pencilContainer"] {
     color: $text;
   }
 }
+
+// Keybinds popout
+div[class|="keyboardShortcutsModal"] span[class|="key"] {
+  color: $crust !important;
+
+  svg g {
+    fill: $crust !important;
+  }
+}


### PR DESCRIPTION
![image](https://github.com/catppuccin/discord/assets/53945697/4574ef68-3c84-439f-a55d-218a1e98e7bd)
the text was white before now its not yippee