### PR TITLE
fix: Members bar fill to bottom

### DIFF
--- a/src/components/_chat.scss
+++ b/src/components/_chat.scss
@@ -615,3 +615,8 @@ div[class|="chat"] div[class|="homeContainer"] {
 .messagelogger-deleted div a {
   color: #{darken($red, 5%)} !important;
 }
+
+// Members sidebar
+aside[class="membersWrap"] {
+  height: 100%;
+}


### PR DESCRIPTION
![image](https://github.com/catppuccin/discord/assets/53945697/7eb2d3d0-5f4a-4a98-9f44-6102dc8e6c3d)
Now it fills to the bottom waow