### PR TITLE
Fix: streaming setting selectors and unthemed role link button

### DIFF
--- a/src/components/_popouts.scss
+++ b/src/components/_popouts.scss
@@ -708,3 +708,11 @@ div[class^="keyboardShortcutsModal"] span[class^="key"] {
     }
   }
 }
+
+// Start streaming settings switches
+div[class^="qualitySettingsContainer"] div[class^="settingsGroup"] {
+  div[class*="selectorTextSelected_"],
+  button[class*="selectorButton_"]:hover div[class*="selectorText_"] {
+    color: $crust !important;
+  }
+}

--- a/src/components/_variables.scss
+++ b/src/components/_variables.scss
@@ -131,6 +131,8 @@ html {
   --yellow-300: #{$yellow};
   --red-400: #{$red};
 
+  --brand-500: #{$brand};
+
   --primary-400: #{$subtext1};
   --primary-dark-700: #{$crust};
 
@@ -284,6 +286,8 @@ html {
   --interactive-muted: #{adjust-color($text, $alpha: -0.7)};
   --interactive-hover: #{$text};
   --interactive-active: #{$text};
+
+  --search-popout-option-non-text-color: #{$subtext0};
 }
 
 ::selection {


### PR DESCRIPTION
![image](https://github.com/catppuccin/discord/assets/53945697/3a2be149-81cf-4da5-8274-35329d4fdb14)
This now properly uses accent

![image](https://github.com/catppuccin/discord/assets/53945697/96b4e0ae-02f3-4184-a405-437ae778eefb)
These are now crust