### PR TITLE
fix: miscolored video play buttons

### DIFF
--- a/src/components/_chat.scss
+++ b/src/components/_chat.scss
@@ -334,7 +334,7 @@ div[class^="chat"]
 // Threads header icon
 div[class^="messagesWrapper"]
   ol[class^="scrollerInner"]
-  div[class^="container"]:not([class*="cozy"])
+  > div[class^="container"]:not([class*="cozy"])
   div[class^="iconWrapper"] {
   background-color: $brand;
   svg[class^="icon"] {


### PR DESCRIPTION
Due to not looking around enough on fixing the Forum channel header icons, turns out it also affected some video play buttons.

![image](https://github.com/catppuccin/discord/assets/53945697/b338a573-8f98-4fdd-81a5-803e2933a0f4)
![image](https://github.com/catppuccin/discord/assets/53945697/06d01de2-b90a-4797-8255-b36e8b95bb94)

