### PR TITLE
fix: popouts have randomized id

### DIFF
--- a/src/components/_popouts.scss
+++ b/src/components/_popouts.scss
@@ -116,6 +116,13 @@ div[class^="layerContainer"] [role="menu"] {
     }
 
     div[class*="container"] {
+      div[class^="popoutBottom"] {
+        // Voice channel connection secured icon
+        span[class^="secured"]::before {
+          @include recolor($green);
+        }
+      }
+
       div[class*="autocompleteArrow_"],
       header {
         background-color: $mantle;
@@ -715,9 +722,4 @@ div[class^="qualitySettingsContainer"] div[class^="settingsGroup"] {
   button[class*="selectorButton_"]:hover div[class*="selectorText_"] {
     color: $crust !important;
   }
-}
-
-// Voice channel connection secured icon
-#popout_101814 span[class^="secured"]::before {
-  @include recolor($green);
 }


### PR DESCRIPTION
Oops the icon lock didn't work because I hardcoded the popout id haha isn't it cool how it only randomizes on reload not on opening and closing