### PR TITLE
fix: boost progress bar animation

### DIFF
--- a/src/components/_pages.scss
+++ b/src/components/_pages.scss
@@ -562,13 +562,8 @@ div[class^="sidebar"] div[class^="container"] {
 
   &:hover {
     div[class^="progressBar"] {
-      background: linear-gradient(
-        90deg,
-        hsl(221, 70%, 55.5%),
-        $mauve 34%,
-        $blue 67%,
-        $mauve
-      );
+      background: linear-gradient(90deg, $blue, $mauve 34%, $blue 67%, $mauve);
+      background-size: 300% 100%;
     }
   }
 


### PR DESCRIPTION
![image](https://github.com/catppuccin/discord/assets/53945697/64418df6-135e-4d70-ae97-2426af4e326f)
This thing actually animates right now