### PR TITLE
fix: Reaction numbers glow on hover

### DIFF
--- a/src/components/_chat.scss
+++ b/src/components/_chat.scss
@@ -36,7 +36,7 @@
   // reactions
   [id^="message-reactions"] {
     div[class^="reaction"] {
-      &:hover {
+      &:not(div[class^="reactionCount"]):hover {
         background-color: var(--brand-experiment-20a);
         border-color: var(--brand-experiment-30a);
       }


### PR DESCRIPTION
Oops that shouldn't have slipped for so long