### PR TITLE
fix: Color Selector Popout and Stream select caret

### DIFF
--- a/src/components/_chat.scss
+++ b/src/components/_chat.scss
@@ -437,6 +437,14 @@ div[class^="callContainer"] {
         background-color: $red !important;
         color: $crust !important;
       }
+
+      div[class*="clipsEnabledIndicator"] {
+        // This covers clipBadgeIcon and clipBadgeText
+        div[class^="clipBadge"] {
+          background-color: $brand !important;
+          color: $crust;
+        }
+      }
     }
 
     button[class*="leftTrayIcon_"][class*="buttonColor_"] {
@@ -454,6 +462,10 @@ div[class^="callContainer"] {
 
         [class*="centerIcon_"] {
           color: $crust;
+        }
+
+        svg[class^="contextMenuCaret"] path {
+          stroke: $crust !important;
         }
       }
 

--- a/src/components/_popouts.scss
+++ b/src/components/_popouts.scss
@@ -751,6 +751,11 @@ div[class*="phoneFieldPopout"] {
   }
 }
 
+// Color Picker Popout
+div[class^="customColorPicker"] {
+  background: $mantle !important;
+}
+
 // Student hub icon
 div[class^="layerContainer"]
   div[class*="modalContent"]


### PR DESCRIPTION
Fixes the color selector for changing folder and user banner color, as well as the caret found when you are watching more than 1 stream, and also fixed the new clips enabled indicator because that's new