### PR TITLE
fix: match new status badge colors

### DIFF
--- a/src/components/_details.scss
+++ b/src/components/_details.scss
@@ -1,5 +1,6 @@
 // online
 rect[fill="#23a55a"],
+rect[fill="#299f5b"],
 foreignObject[mask="url(#svg-mask-status-online)"] > div,
 div[class^="dotOnline"],
 i[class^="statusOnline"] {
@@ -7,29 +8,34 @@ i[class^="statusOnline"] {
   background-color: $green !important;
 }
 
-rect[fill="rgba(35, 165, 90, 1)"] {
+rect[fill="rgba(35, 165, 90, 1)"],
+rect[fill="rgba(41, 159, 91, 1)"] {
   fill: $green !important;
 }
 
 // idle
 rect[fill="#f0b232"],
+rect[fill="#e6ae3c"],
 foreignObject[mask="url(#svg-mask-status-idle)"] > div {
   fill: $yellow !important;
   background-color: $yellow !important;
 }
 
-rect[fill="rgba(240, 178, 50, 1)"] {
+rect[fill="rgba(240, 178, 50, 1)"],
+rect[fill="rgba(230, 174, 60, 1)"] {
   fill: $yellow !important;
 }
 
 // dnd
 rect[fill="#f23f43"],
+rect[fill="#ea474b"],
 foreignObject[mask="url(#svg-mask-status-dnd)"] > div {
   fill: $red !important;
   background-color: $red !important;
 }
 
-rect[fill="rgba(242, 63, 67, 1)"] {
+rect[fill="rgba(242, 63, 67, 1)"],
+rect[fill="rgba(230, 174, 60, 1)"] {
   fill: $red !important;
 }
 
@@ -44,12 +50,14 @@ i[class^="statusOffline"] {
   background-color: $subtext0 !important;
 }
 
-rect[fill="rgba(130, 133, 143, 1)"] {
+rect[fill="rgba(130, 133, 143, 1)"],
+rect[fill="rgba(128, 132, 142, 1)"] {
   fill: $subtext0 !important;
 }
 
 // streaming
-rect[fill="#593695"] {
+rect[fill="#593695"],
+rect[fill="#5b3a91"] {
   fill: $mauve !important;
 }
 


### PR DESCRIPTION
The newest Discord update changes the color of the user status badges, so I've updated the CSS rules so they match again.