### PR TITLE
fix: theme syntax highlighting in message input box

### DIFF
--- a/src/catppuccin-frappe.theme.scss
+++ b/src/catppuccin-frappe.theme.scss
@@ -10,10 +10,11 @@
 
 @use "sass:math";
 @use "@catppuccin/palette/scss/frappe" as *;
+@use "@catppuccin/highlightjs/sass/theme";
 
 $brand: $blue;
 
 @import "theme";
 .theme-dark {
-  @import "@catppuccin/highlightjs/sass/catppuccin-frappe";
+  @include theme.highlights("frappe", "hex");
 }

--- a/src/catppuccin-latte.theme.scss
+++ b/src/catppuccin-latte.theme.scss
@@ -10,6 +10,7 @@
 
 @use "sass:math";
 @use "@catppuccin/palette/scss/latte" as *;
+@use "@catppuccin/highlightjs/sass/theme";
 
 $brand: $blue;
 
@@ -349,6 +350,6 @@ nav[class*="guilds-"].theme-dark {
 }
 
 @import "theme";
-.theme-light {
-  @import "@catppuccin/highlightjs/sass/catppuccin-latte";
+.theme-dark {
+  @include theme.highlights("latte", "hex");
 }

--- a/src/catppuccin-macchiato.theme.scss
+++ b/src/catppuccin-macchiato.theme.scss
@@ -10,10 +10,11 @@
 
 @use "sass:math";
 @use "@catppuccin/palette/scss/macchiato" as *;
+@use "@catppuccin/highlightjs/sass/theme";
 
 $brand: $blue;
 
 @import "theme";
 .theme-dark {
-  @import "@catppuccin/highlightjs/sass/catppuccin-macchiato";
+  @include theme.highlights("macchiato", "hex");
 }

--- a/src/catppuccin-mocha.theme.scss
+++ b/src/catppuccin-mocha.theme.scss
@@ -10,10 +10,11 @@
 
 @use "sass:math";
 @use "@catppuccin/palette/scss/mocha" as *;
+@use "@catppuccin/highlightjs/sass/theme";
 
 $brand: $blue;
 
 @import "theme";
 .theme-dark {
-  @import "@catppuccin/highlightjs/sass/catppuccin-mocha";
+  @include theme.highlights("mocha", "hex");
 }


### PR DESCRIPTION
Our own Highlight.js port sets the selector to `code ...`, which works for code blocks in sent messages but not in the text input box. We can change this selector ourselves, which is what this PR does.

| Before | After |
| --- | --- |
| ![CleanShot 2024-06-17 at 15 14 50@2x](https://github.com/catppuccin/discord/assets/47499684/a0157335-6a48-4255-821d-ff9a3c37fb03) | ![CleanShot 2024-06-17 at 15 19 52@2x](https://github.com/catppuccin/discord/assets/47499684/a897438b-e4a2-4a7b-8be3-0e1032239809) |