### PR TITLE
Fix: Theme channels & roles

### DIFF
--- a/src/components/_chat.scss
+++ b/src/components/_chat.scss
@@ -550,48 +550,45 @@ div[class*="giftCodeContainer"] [class*="tile"] {
 
 // channels & roles
 div[class*="chat_"] {
-  // header
-  section[class*="header_"] {
-    background-color: $mantle !important;
-  }
-
   div[class*="content_"][class*="container_"] {
-    background-color: $mantle !important;
-
-    div[class*="container"] {
-      background-color: $base;
-    }
-
-    div[class*="search_"] {
-      background-color: $base !important;
-
-      input::placeholder {
-        color: $overlay0;
+    // customise
+    div[class^="profileCard_"] {
+      background-color: $surface0;
+      div[class^="role_"] {
+        background-color: $mantle;
       }
     }
 
-    div[class*="browser"] {
-      div[class*="content"] div[class^="container"] {
-        background-color: $base;
+    div[class^="prompt_"] {
+      background-color: $surface0;
+      div[class^="optionButtonWrapper_"][class*="selected_"] {
+        background-color: $mantle;
+        border-color: $mantle;
       }
-    }
-
-    div[class*="scrollerContainer_"] {
-      background-color: $mantle;
-
-      div[class*="checkIcon_"][style*="opacity: 1;"] > svg > path {
-        fill: $crust;
+      div[class^="select_"] {
+        div[class$="control"] {
+          background-color: $mantle;
+          border-color: $mantle;
+          div[class^="selectValuePill_"] {
+            background-color: $surface0;
+          }
+        }
+        div[class$="menu"] {
+          background-color: $base;
+          border-color: $mantle;
+        }
       }
-    }
-
-    div[role="tablist"] {
-      background-color: $mantle;
-      border-bottom: 2px solid $surface0;
     }
     
-    // channels tab
-    div[class*="pageBody_"] {
-      background-color: $mantle;
+    // channels
+    div[class*="search_"] input::placeholder {
+      color: $overlay1;
+    }
+    div[class^="channelRow_"] {
+      background-color: $surface0;
+      &:hover:not([class*="disabled_"]) {
+          background-color: $base;
+      }
     }
   }
 }

--- a/src/components/_chat.scss
+++ b/src/components/_chat.scss
@@ -552,14 +552,14 @@ div[class*="giftCodeContainer"] [class*="tile"] {
 div[class*="chat_"] {
   // header
   section[class*="header_"] {
-    background-color: $mantle;
+    background-color: $mantle !important;
   }
 
   div[class*="content_"][class*="container_"] {
-    background-color: $mantle;
+    background-color: $mantle !important;
 
     div[class*="container"] {
-      background-color: $mantle;
+      background-color: $base;
     }
 
     div[class*="search_"] {
@@ -587,6 +587,11 @@ div[class*="chat_"] {
     div[role="tablist"] {
       background-color: $mantle;
       border-bottom: 2px solid $surface0;
+    }
+    
+    // channels tab
+    div[class*="pageBody_"] {
+      background-color: $mantle;
     }
   }
 }

--- a/src/components/_variables.scss
+++ b/src/components/_variables.scss
@@ -73,8 +73,7 @@ html {
   --background-mobile-primary: #{$base};
   --background-mobile-secondary: #{$mantle};
 
-  --home-background: #{base}
-
+  --home-background: #{$base};
   --chat-background: #{$base};
   --chat-border: #{$crust};
   --chat-input-container-background: #{$base};

--- a/src/components/_variables.scss
+++ b/src/components/_variables.scss
@@ -73,6 +73,8 @@ html {
   --background-mobile-primary: #{$base};
   --background-mobile-secondary: #{$mantle};
 
+  --home-background: #{base}
+
   --chat-background: #{$base};
   --chat-border: #{$crust};
   --chat-input-container-background: #{$base};


### PR DESCRIPTION
`div[class*="pageBody_"]` is required to properly theme the Browse Channels tab.

As far as I can tell, the only thing that `div[class*="content_"][class*="container_"] { div[class*="container"] }` affects is the box around dropdowns in the Customise tab, so I've changed it to match the background colour of those prompts.

Closes #312 