### PR TITLE
Fix: Theme audio/video controls in search results

### DIFF
--- a/src/components/_chat.scss
+++ b/src/components/_chat.scss
@@ -1,21 +1,4 @@
 [class^="chatContent"] {
-  div[class*="wrapperAudio_"],
-  div[class*="imageWrapper_"] {
-    div[class*="audioControls"],
-    div[class*="videoControls_"] {
-      background-color: #{adjust-color($crust, $alpha: -0.2)};
-
-      svg[class*="controlIcon_"] {
-        opacity: 1;
-        color: $subtext1;
-      }
-
-      div[class*="mediaBarInteractionVolume"] {
-        background-color: #{adjust-color($crust, $alpha: -0.2)};
-      }
-    }
-  }
-
   // new message ruler
   #---new-messages-bar {
     span[class^="unreadPill"] {
@@ -122,6 +105,23 @@
         background-color: $green;
         color: $crust;
       }
+    }
+  }
+}
+
+div[class*="wrapperAudio_"],
+div[class*="imageWrapper_"] {
+  div[class*="audioControls"],
+  div[class*="videoControls_"] {
+    background-color: #{adjust-color($crust, $alpha: -0.2)};
+
+    svg[class*="controlIcon_"] {
+      opacity: 1;
+      color: $subtext1;
+    }
+
+    div[class*="mediaBarInteractionVolume"] {
+      background-color: #{adjust-color($crust, $alpha: -0.2)};
     }
   }
 }


### PR DESCRIPTION
Search results aren't contained within the `chatContent` element, but the audio/video controls still use the same classes, so it just needs to be moved outside the class.