### PR TITLE
Fix: Make keybinds text in loading tip visible

### DIFF
--- a/src/components/_details.scss
+++ b/src/components/_details.scss
@@ -345,11 +345,3 @@ div[class*="actions_"] {
     fill: $text !important;
   }
 }
-
-// Loading tip keys
-div[class*="fixClipping"]
-  div[class^="tip"]
-  div[class*="keybind"]
-  span[class^="key"] {
-  color: $crust;
-}


### PR DESCRIPTION
Related to #316 