### PR TITLE
build: update and simplify script

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
-  "name": "catppuccin-discord",
+  "private": true,
+  "name": "@catppuccin/discord",
   "version": "0.2.0",
-  "description": "Catppuccin theme for Discord",
+  "description": "Soothing pastel theme for Discord",
   "repository": "https://github.com/catppuccin/discord",
   "license": "MIT",
   "author": {
@@ -14,16 +15,15 @@
       "email": "hey@winston.sh"
     }
   ],
-  "private": true,
+  "type": "module",
   "scripts": {
-    "build": "mkdir -p dist/dist && sass -I node_modules --no-charset --no-source-map src:dist/dist",
-    "release": "node build.js && mkdir -p dist/dist && sass -I node_modules --style=compressed --no-charset --no-source-map src:dist/dist && rm src/catppuccin-*-*.theme.scss",
-    "watch": "mkdir -p dist/dist && sass -I node_modules --no-charset --no-source-map src:dist/dist -w",
-    "prepare": "husky install"
+    "build": "node build.js",
+    "prepare": "husky install",
+    "format": "prettier --write ."
   },
   "devDependencies": {
     "@catppuccin/highlightjs": "^0.1.3",
-    "@catppuccin/palette": "^0.1.6",
+    "@catppuccin/palette": "^.1.20",
     "husky": ">=6",
     "lint-staged": ">=10",
     "prettier": "^2.7.1",

--- a/src/catppuccin-frappe.theme.scss
+++ b/src/catppuccin-frappe.theme.scss
@@ -12,8 +12,6 @@
 @use "@catppuccin/palette/scss/frappe" as *;
 @use "@catppuccin/highlightjs/sass/theme";
 
-$brand: $blue;
-
 @import "theme";
 .theme-dark {
   @include theme.highlights("frappe", "hex");

--- a/src/catppuccin-latte.theme.scss
+++ b/src/catppuccin-latte.theme.scss
@@ -12,8 +12,6 @@
 @use "@catppuccin/palette/scss/latte" as *;
 @use "@catppuccin/highlightjs/sass/theme";
 
-$brand: $blue;
-
 // for dark sidebars :clueless:
 :root .theme-dark {
   @import "@catppuccin/palette/scss/mocha";

--- a/src/catppuccin-macchiato.theme.scss
+++ b/src/catppuccin-macchiato.theme.scss
@@ -12,8 +12,6 @@
 @use "@catppuccin/palette/scss/macchiato" as *;
 @use "@catppuccin/highlightjs/sass/theme";
 
-$brand: $blue;
-
 @import "theme";
 .theme-dark {
   @include theme.highlights("macchiato", "hex");

--- a/src/catppuccin-mocha.theme.scss
+++ b/src/catppuccin-mocha.theme.scss
@@ -12,8 +12,6 @@
 @use "@catppuccin/palette/scss/mocha" as *;
 @use "@catppuccin/highlightjs/sass/theme";
 
-$brand: $blue;
-
 @import "theme";
 .theme-dark {
   @include theme.highlights("mocha", "hex");

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,10 +7,10 @@
   resolved "https://registry.yarnpkg.com/@catppuccin/highlightjs/-/highlightjs-0.1.3.tgz#795dfec3e65260255e63269d49961e7a3339e9f1"
   integrity sha512-NpC67ktdwR2nvGYb18uuMU8QDrwL+NUZJ3hMqhyRmVLAr9xJcuFOcDluJAKE3V13xD95aHTaIvyEW6PiWlaQwA==
 
-"@catppuccin/palette@^0.1.6":
-  version "0.1.6"
-  resolved "https://registry.yarnpkg.com/@catppuccin/palette/-/palette-0.1.6.tgz#50f10b0cdfad604a07224841f3b1b88287ea212e"
-  integrity sha512-Jf4UD510Q0n1CadMY0OoSJU0wBpphWDGAvToGrb/1mub9v2/ZSGUBMfvAKyOdKB4yyfkN8Ym1n8+1bNAW18doA==
+"@catppuccin/palette@^.1.20":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@catppuccin/palette/-/palette-1.2.0.tgz#0220cab23632ef86af1dc9f37995a882740fa77a"
+  integrity sha512-R5fxLcU47mRcsdQkXZBNfxt7SdEqLGWb1qhEKBrnYfEB4ZWOQRBEow4e78PKxaFUECBNOs6uEkwvwxFL9FmQqQ==
 
 aggregate-error@^3.0.0:
   version "3.1.0"


### PR DESCRIPTION
Updates the script to use the more modern web ESM syntax (as opposed to the old Node.js CJS syntax). I've also simplified the script to use Catppuccin's npm package - which is already installed and used in the SASS files to import the colors, only updated the version of it - and use the SASS API for compilation instead of using the CLI as an npm script. I did some updates to the package.json as well (cleaned up the scripts, updated metadata).