### PR TITLE
fix: activity panel buttons colour + others

### DIFF
--- a/src/components/_buttons.scss
+++ b/src/components/_buttons.scss
@@ -2,6 +2,7 @@
 [class*="lookFilled_"] {
   &[class*="colorBrand_"],
   &[class*="colorBrandNew_"],
+  &[class*="colorBrandInverted_"],
   &[class*="colorLink_"],
   &[class*="colorYellow_"],
   &[class*="colorRed_"],
@@ -150,4 +151,9 @@ div[role="radio"][class*="selected"] {
 // Create a server back button
 div[class^="layerContainer"] button[class^="backButton"][class*="lookBlank"] {
   color: $text;
+}
+
+// Make stream settings selected buttons text legible
+.vcd-screen-picker-radio[data-checked=true] > [class^="defaultColor_"] {
+  color: $crust;
 }

--- a/src/components/_details.scss
+++ b/src/components/_details.scss
@@ -336,13 +336,9 @@ div[class*="actions_"] {
   button[class*="red_"] {
     background: $red;
   }
+}
 
-  button svg > path {
-    fill: $crust !important;
-  }
-
-  // bodge for streaming "close stream" button
-  div[class^="panelButtonContainer"] button svg > path {
-    fill: $text !important;
-  }
+// "G" in Go Live icon
+[class^="gameWrapper_"] [class^="icon_"] {
+  color: $crust;
 }

--- a/src/components/_pages.scss
+++ b/src/components/_pages.scss
@@ -114,16 +114,6 @@ div[class^="contentRegion"] {
     }
   }
 
-  #keybinds-tab {
-    span[class*="key"] {
-      color: $crust;
-
-      g {
-        fill: $crust;
-      }
-    }
-  }
-
   #subscriptions-tab {
     [class^="sectionAccountCredit"],
     [class^="subscriptionDetails"] {


### PR DESCRIPTION
Closes #281. Also fixes the text colours of the G icon in "Go Live" when streaming, keybinds tab in settings, selected buttons in stream settings popup, and "Subscribe" in Nitro settings tab