### PR TITLE
Fix: remove embeds hover color

### DIFF
--- a/src/components/_details.scss
+++ b/src/components/_details.scss
@@ -249,22 +249,32 @@ div[class^="tags"] div[class^="pinIcon"] path {
 
 // speaking indicator
 div[class*="avatarSpeaking_"] {
-  -webkit-box-shadow: inset 0 0 0 2px $green,
+  -webkit-box-shadow:
+    inset 0 0 0 2px $green,
     inset 0 0 0 3px var(--background-secondary);
-  box-shadow: inset 0 0 0 2px $green,
+  box-shadow:
+    inset 0 0 0 2px $green,
     inset 0 0 0 3px var(--background-secondary);
 }
 
 div[class*="videoLayer_"] > div[class^="tileChild"] > div[class^="border"] {
   &[class*="speaking_"] {
-    -webkit-box-shadow: inset 0 0 0 2px $green, inset 0 0 0 3px $green;
-    box-shadow: inset 0 0 0 2px $green, inset 0 0 0 3px $green;
+    -webkit-box-shadow:
+      inset 0 0 0 2px $green,
+      inset 0 0 0 3px $green;
+    box-shadow:
+      inset 0 0 0 2px $green,
+      inset 0 0 0 3px $green;
   }
 
   // this is when emojis fly across the tile
   &[class*="voiceChannelEffect_"] {
-    -webkit-box-shadow: inset 0 0 0 2px $brand, inset 0 0 0 3px $brand;
-    box-shadow: inset 0 0 0 2px $brand, inset 0 0 0 3px $brand;
+    -webkit-box-shadow:
+      inset 0 0 0 2px $brand,
+      inset 0 0 0 3px $brand;
+    box-shadow:
+      inset 0 0 0 2px $brand,
+      inset 0 0 0 3px $brand;
   }
 }
 
@@ -341,4 +351,9 @@ div[class*="actions_"] {
 // "G" in Go Live icon
 [class^="gameWrapper_"] [class^="icon_"] {
   color: $crust;
+}
+
+// Darken delete icon on hover
+[class^="hoverButton"]:not([class^="anchor"]):hover > svg {
+  color: $base;
 }


### PR DESCRIPTION
Apparently this has been [fixed in my fork](https://github.com/ToxicAven/discord/blob/90ea0d7d4e4c7fd0e1b0ef9ce99cac691c95e4a7/src/components/_aven.scss#L775-L778) of the theme for like a year, and I just never noticed it otherwise.

before
![image](https://github.com/user-attachments/assets/adc18017-4989-4707-b97a-c0e7f8c8091d)
after
![image](https://github.com/user-attachments/assets/25c597f1-6159-4ab0-b190-1c4e1c6f2f98)

Thanks @rubyowo 