### PR TITLE
fix: light theme priority

### DIFF
--- a/src/catppuccin-latte.theme.scss
+++ b/src/catppuccin-latte.theme.scss
@@ -12,15 +12,6 @@
 @use "@catppuccin/palette/scss/latte" as *;
 @use "@catppuccin/highlightjs/sass/theme";
 
-.visual-refresh.theme-dark,
-.visual-refresh .theme-dark {
-  @import "@catppuccin/palette/scss/frappe";
-  $brand: $blue;
-
-  @import "components/tweaks/dark";
-  @import "theme";
-}
-
 .visual-refresh.theme-light,
 .visual-refresh .theme-light {
   $brand: $blue;
@@ -29,4 +20,13 @@
   @import "theme";
 
   @include theme.highlights("latte");
+}
+
+.visual-refresh.theme-dark,
+.visual-refresh .theme-dark {
+  @import "@catppuccin/palette/scss/frappe";
+  $brand: $blue;
+
+  @import "components/tweaks/dark";
+  @import "theme";
 }

--- a/src/components/tweaks/_light.scss
+++ b/src/components/tweaks/_light.scss
@@ -1,6 +1,7 @@
 & {
   // flip (Discord light mode uses in places where contrast is good)
   --white: #{$crust} !important;
+  --white-400: #{$crust} !important;
   --white-500: #{$crust} !important;
   --white-600: #{$surface1} !important;
   --white-700: #{$surface2} !important;


### PR DESCRIPTION
Discord did some stylesheet reordering that caused the dark vars to overwrite the light vars when in light mode.

fixes: #401



I have some changes in the works that should fix these stylesheet ordering issues entirely.