### PR TITLE
 Update Docs to Include Legcord

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,27 +67,30 @@
 @import url("https://catppuccin.github.io/discord/dist/catppuccin-frappe-maroon.theme.css");
 ```
 
-### [Legcord](https://github.com/Legcord/Legcord)
+#### [Legcord](https://github.com/Legcord/Legcord)
+<details>
+  <summary>Instructions</summary>
 
-1. Navigate to Settings (Legcord app) > Legcord > Themes
-2. Paste the link to the theme's CSS file
+  1. Navigate to Settings (Legcord app) > Legcord > Themes
+  2. Paste the link to the theme's CSS file
 
-```css
-/* latte */
-https://catppuccin.github.io/discord/dist/catppuccin-latte.theme.css
-/* frappe */
-https://catppuccin.github.io/discord/dist/catppuccin-frappe.theme.css
-/* macchiato */
-https://catppuccin.github.io/discord/dist/catppuccin-macchiato.theme.css
-/* mocha */
-https://catppuccin.github.io/discord/dist/catppuccin-mocha.theme.css
+  ```
+  /* latte */
+  https://catppuccin.github.io/discord/dist/catppuccin-latte.theme.css
+  /* frappe */
+  https://catppuccin.github.io/discord/dist/catppuccin-frappe.theme.css
+  /* macchiato */
+  https://catppuccin.github.io/discord/dist/catppuccin-macchiato.theme.css
+  /* mocha */
+  https://catppuccin.github.io/discord/dist/catppuccin-mocha.theme.css
 
-/* You can also append Catppuccin colors to customize the accent, e.g. */
-/* mocha (pink accent)*/
-https://catppuccin.github.io/discord/dist/catppuccin-mocha-pink.theme.css
-/* frappe (maroon accent) */
-https://catppuccin.github.io/discord/dist/catppuccin-frappe-maroon.theme.css
-```
+  /* You can also append Catppuccin colors to customize the accent, e.g. */
+  /* mocha (pink accent)*/
+  https://catppuccin.github.io/discord/dist/catppuccin-mocha-pink.theme.css
+  /* frappe (maroon accent) */
+  https://catppuccin.github.io/discord/dist/catppuccin-frappe-maroon.theme.css
+  ```
+</details>
 
 ### [Stylus](https://github.com/openstyles/stylus)
 


### PR DESCRIPTION
This PR updates the documentation to include instructions and support for using Legcord. The changes aim to help users who wish to apply the Catppuccin theme to Legcord, as discussed in [Discussion #2801](https://github.com/catppuccin/catppuccin/discussions/2801).

### Summary of changes:
- Added Legcord usage instructions to the documentation
- compatibility and theming steps for Legcord users
