### PR TITLE
Fix various input fields and containers being filled with surface2

### DIFF
--- a/src/components/_details.scss
+++ b/src/components/_details.scss
@@ -30,7 +30,7 @@ div[class^="expandedFolderBackground_"] {
 // Switches
 // Literally a single switch doesnt have the parent control_ class... so annoying
 // div[class^="container_"][style*="opacity: 1; background-color:"]
-div[class^="control_"] > div[class^="container_"] {
+div[class^="control_"] > div[class^="container_"] > div > div[data-toggleable-component="switch"] {
   background-color: #{$surface2} !important;
   transition: background-color 0.2s;
 


### PR DESCRIPTION
Increase specificity to fix this issue
Before
<img width="1225" height="988" alt="image" src="https://github.com/user-attachments/assets/ebee9719-6a19-4456-b40b-0e0226d09bb0" />
After
<img width="1445" height="968" alt="image" src="https://github.com/user-attachments/assets/d291f203-e639-478b-9d39-6d480c3f2650" />
