### PR TITLE
Fix: Updated the README to redirect user to raw view of theme flavour .css

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@
 
 1. Download your preferred flavour:
 
-- 🌻 [Latte](./themes/latte.theme.css?raw=1)
+- 🌻 [Latte](./themes/latte.theme.css?raw=true)
 - 🪴 [Frappe](./themes/frappe.theme.css?raw=1)
 - 🌺 [Macchiato](./themes/macchiato.theme.css?raw=1)
 - 🌿 [Mocha](./themes/mocha.theme.css?raw=1)

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@
 - 🌻 [Latte](../../raw/main/themes/latte.theme.css)
 - 🪴 [Frappe](../../raw/main/themes/frappe.theme.css)
 - 🌺 [Macchiato](../../raw/main/themes/macchiato.theme.css)
-- 🌿 [Mocha](../../raw/main/themes/mocha.theme.css)
+- 🌿 [Mocha](/../raw/main/themes/mocha.theme.css)
 
 2. Copy the downloaded file to your BetterDiscord themes folder.
 3. Enable the theme in BetterDiscord settings.

--- a/README.md
+++ b/README.md
@@ -38,10 +38,10 @@
 
 1. Download your preferred flavour:
 
-- 🌻 [Latte](./themes/latte.theme.css?raw=true)
-- 🪴 [Frappe](./themes/frappe.theme.css?raw=1)
-- 🌺 [Macchiato](./themes/macchiato.theme.css?raw=1)
-- 🌿 [Mocha](./themes/mocha.theme.css?raw=1)
+- 🌻 [Latte](../../raw/main/themes/latte.theme.css)
+- 🪴 [Frappe](../../raw/main/themes/frappe.theme.css)
+- 🌺 [Macchiato](../../raw/main/themes/macchiato.theme.css)
+- 🌿 [Mocha](../../raw/main/themes/mocha.theme.css)
 
 2. Copy the downloaded file to your BetterDiscord themes folder.
 3. Enable the theme in BetterDiscord settings.

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@
 - 🌻 [Latte](../../raw/main/themes/latte.theme.css)
 - 🪴 [Frappe](../../raw/main/themes/frappe.theme.css)
 - 🌺 [Macchiato](../../raw/main/themes/macchiato.theme.css)
-- 🌿 [Mocha](/../raw/main/themes/mocha.theme.css)
+- 🌿 [Mocha](../../raw/main/themes/mocha.theme.css)
 
 2. Copy the downloaded file to your BetterDiscord themes folder.
 3. Enable the theme in BetterDiscord settings.


### PR DESCRIPTION
The links to the raw .css file on the flavours section sends them to which looks like the screenshot when clicked "https://github.com/catppuccin/discord/blob/main/themes/frappe.theme.css?raw=1"

then reloading that page redirects to the proper raw view of the file "https://raw.githubusercontent.com/catppuccin/discord/refs/heads/main/themes/frappe.theme.css"

I just updated the README so the link directly sends the user to the `raw.githubusercontent.com`  view instead.

<img width="800" height="600" alt="readme showcase" src="https://github.com/user-attachments/assets/5d1150a9-5130-4065-b4c7-c9d11321cb2d" />

I hope the gif and explanation helps, if not I'm glad to clarify.
