### PR TITLE
fix: improve dark mode contrast

### DIFF
--- a/src/components/_details.scss
+++ b/src/components/_details.scss
@@ -29,28 +29,49 @@ span[class^="folderGroupBackground_"] {
 
 // Switches
 label[class^="container_"] > div[data-mana-component="switch"] {
-  background-color: #{$surface2} !important;
   border: unset !important;
+
+  background-color: #{$surface2} !important; // track background
   transition: background-color 0.2s;
 
-  &:hover {
-    background-color: #{$surface1} !important;
+  > svg {
+    > rect {
+      fill: var(--white); // thumb background
+      transition: fill 0.2s;
+    }
+
+    > svg > g > path {
+      fill: #{$surface2} !important; // indicator icon
+    }
   }
 
-  > svg > rect {
-    fill: var(--white);
-    transition: fill 0.2s;
+  &:hover {
+    background-color: #{$surface1} !important; // track hover
+
+    > svg > svg > g > path {
+      fill: #{$surface1} !important; // indicator icon hover
+    }
   }
 
   &:has(+ span > input:checked) {
-    background-color: var(--brand-500) !important;
+    background-color: var(--brand-500) !important; // track checked
 
-    &:hover {
-      background-color: var(--brand-560) !important;
+    > svg {
+      > rect {
+        fill: #{$crust}; // thumb checked
+      }
+
+      > svg > g > path {
+        fill: var(--brand-500) !important; // indicator icon checked
+      }
     }
 
-    > svg > rect {
-      fill: #{$crust};
+    &:hover {
+      background-color: var(--brand-560) !important; // track checked hover
+
+      > svg > svg > g > path {
+        fill: var(--brand-560) !important; // indicator icon checked hover
+      }
     }
   }
 }

--- a/src/components/_details.scss
+++ b/src/components/_details.scss
@@ -4,7 +4,7 @@ $online-indicators: (
   #ffc04e: $yellow,
   #da3e44: $red,
   #84858d: $overlay1,
-  #9147ff: var(--twitch),
+  #9147ff: var(--platform-twitch),
 );
 @each $color, $var in $online-indicators {
   svg [fill="#{$color}"],

--- a/src/components/_variables.scss
+++ b/src/components/_variables.scss
@@ -322,9 +322,9 @@
   --icon-status-dnd: #{$red};
   --icon-status-offline: #{$subtext1};
 
-  --twitch: #{darken($mauve, 10%)};
-  --playstation: #{darken($blue, 10%)};
-  --spotify: #{$green};
+  --platform-twitch: #{darken($mauve, 10%)};
+  --platform-playstation: #{darken($blue, 10%)};
+  --platform-spotify: #{$green};
 
   --notice-background-critical: #{$red};
   --notice-background-info: #{$blue};

--- a/src/components/tweaks/_dark.scss
+++ b/src/components/tweaks/_dark.scss
@@ -30,6 +30,7 @@ svg[class*="flowerStar_"] + div[class*="childContainer_"],
 div[class*="streamerModeEnabledBtn_"],
 div[class*="nowPlaying_"], // Registered games now playing
 div[class^="pageControlContainer_"], // Selected page control
+svg[class^="checkmarkCircle_"],
 [class*="notice_"][class*="colorBrand_"], [class*="colorStreamerMode_"], [class*="colorSpotify_"], [class*="colorPremium_"], [class*="colorPlayStation_"],
 .interactive:hover {
   --white: #{$crust};

--- a/src/components/tweaks/_dark.scss
+++ b/src/components/tweaks/_dark.scss
@@ -2,8 +2,8 @@
 // Light accents contrast is ok! (rare latte win)
 
 div[class^="item_"][class*="addFriend_"],
-div[class^="numberBadge_"][style*="background-color: var(--background-feedback-notification);"],
-div[class^="numberBadge_"][style*="background-color: var(--badge-notification-background);"],
+div[class*="numberBadge_"][style*="background-color: var(--background-feedback-notification);"],
+div[class*="numberBadge_"][style*="background-color: var(--badge-notification-background);"],
 div[class*="iconBadge_"][class*="isCurrentUserConnected_"],
 span[class*="botTag_"],
 span[class^="unreadPill_"],


### PR DESCRIPTION
this pr simply fixes a few small contrast related issues i've found on dark mode.

**changes:**
- fixes notification badge contrast in dark mode
  - closes #449
- fixes checkmark circle (can find in appearance > theme/app icon) contrast in dark mode
- recolors switch indicator icons (accessibility > show on/off indicators)
- updates platform variable names
  - fixes streamer mode color not being changed